### PR TITLE
feat: add json conversion for genome files

### DIFF
--- a/src/scripts/genomeTransformer.ts
+++ b/src/scripts/genomeTransformer.ts
@@ -1,0 +1,56 @@
+import readline from 'readline';
+import fs from 'fs';
+import path from 'path';
+import { exit } from 'process';
+
+type EntryTuple = [string, string, string, string, string];
+
+interface GenomeData {
+  chromosome: string;
+  start: number;
+  end: number;
+  name?: string;
+  giemsaStains: string;
+}
+
+function serialize([
+  chromosome,
+  start,
+  end,
+  name,
+  giemsaStains,
+]: EntryTuple): GenomeData {
+  return {
+    chromosome,
+    start: parseInt(start),
+    end: parseInt(end),
+    name: name === '' ? undefined : name,
+    giemsaStains,
+  };
+}
+
+(async () => {
+  console.log(process.argv);
+  if (!process.argv[2]) {
+    console.error('Usage transformer.js <file>');
+    exit(1);
+  }
+
+  const filePath = path.join(__dirname, './cytoBand.txt');
+  const fileName = path.parse(filePath).name;
+
+  const fileStream = fs.createReadStream(filePath);
+  const rl = readline.createInterface({
+    input: fileStream,
+    crlfDelay: Infinity,
+  });
+
+  const res: GenomeData[] = [];
+  for await (const line of rl) {
+    const row = line.split('\t') as EntryTuple;
+    res.push(serialize(row));
+  }
+
+  const data = JSON.stringify(res, null, 2);
+  fs.writeFileSync(path.join(__dirname, `${fileName}.json`), data);
+})();


### PR DESCRIPTION
See [ticket](https://app.clickup.com/t/1qv9cx0)

Converts data into complimentary JSON data.

Usage:
```
ts-node /src/scripts/genomeTransformer.ts <file>
```

Note: `<file>` is relative to the directory the script is run from.