### PR TITLE
Make cytobands iterable

### DIFF
--- a/src/components/Chromosome.tsx
+++ b/src/components/Chromosome.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { Canvas, extend } from '@react-three/fiber';
 //import { Position } from '@react-three/drei/helpers/Position';
-import Data from '../chromosomes.json';
 import { OrbitControls } from '@react-three/drei';
 import Cytoband from './Cytoband';
+import Data from '../scripts/cytoBand.json';
 extend({ OrbitControls });
 
 interface ChromProps {
@@ -24,10 +24,9 @@ function Chromosome({
         <ambientLight />
         <pointLight position={[10, 10, 10]} /> */}
       {Data.map((band) => {
-        console.log(selectedLocations.includes(band.location));
-        console.log(band);
+        // console.log(band.name);
         return (
-          <div key={band.id}>hi</div>
+          <div key={band.name}>{band.name}</div>
           // <Cytoband
           //   key={band.id}
           //   id={band.id}

--- a/src/scripts/cytoBand.json
+++ b/src/scripts/cytoBand.json
@@ -1,0 +1,6490 @@
+[
+  {
+    "id": 0,
+    "chromosome": "chr1",
+    "start": 0,
+    "end": 2300000,
+    "name": "1.p36.33",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 1,
+    "chromosome": "chr1",
+    "start": 2300000,
+    "end": 5300000,
+    "name": "1.p36.32",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 2,
+    "chromosome": "chr1",
+    "start": 5300000,
+    "end": 7100000,
+    "name": "1.p36.31",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 3,
+    "chromosome": "chr1",
+    "start": 7100000,
+    "end": 9100000,
+    "name": "1.p36.23",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 4,
+    "chromosome": "chr1",
+    "start": 9100000,
+    "end": 12500000,
+    "name": "1.p36.22",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 5,
+    "chromosome": "chr1",
+    "start": 12500000,
+    "end": 15900000,
+    "name": "1.p36.21",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 6,
+    "chromosome": "chr1",
+    "start": 15900000,
+    "end": 20100000,
+    "name": "1.p36.13",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 7,
+    "chromosome": "chr1",
+    "start": 20100000,
+    "end": 23600000,
+    "name": "1.p36.12",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 8,
+    "chromosome": "chr1",
+    "start": 23600000,
+    "end": 27600000,
+    "name": "1.p36.11",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 9,
+    "chromosome": "chr1",
+    "start": 27600000,
+    "end": 29900000,
+    "name": "1.p35.3",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 10,
+    "chromosome": "chr1",
+    "start": 29900000,
+    "end": 32300000,
+    "name": "1.p35.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 11,
+    "chromosome": "chr1",
+    "start": 32300000,
+    "end": 34300000,
+    "name": "1.p35.1",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 12,
+    "chromosome": "chr1",
+    "start": 34300000,
+    "end": 39600000,
+    "name": "1.p34.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 13,
+    "chromosome": "chr1",
+    "start": 39600000,
+    "end": 43700000,
+    "name": "1.p34.2",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 14,
+    "chromosome": "chr1",
+    "start": 43700000,
+    "end": 46300000,
+    "name": "1.p34.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 15,
+    "chromosome": "chr1",
+    "start": 46300000,
+    "end": 50200000,
+    "name": "1.p33",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 16,
+    "chromosome": "chr1",
+    "start": 50200000,
+    "end": 55600000,
+    "name": "1.p32.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 17,
+    "chromosome": "chr1",
+    "start": 55600000,
+    "end": 58500000,
+    "name": "1.p32.2",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 18,
+    "chromosome": "chr1",
+    "start": 58500000,
+    "end": 60800000,
+    "name": "1.p32.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 19,
+    "chromosome": "chr1",
+    "start": 60800000,
+    "end": 68500000,
+    "name": "1.p31.3",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 20,
+    "chromosome": "chr1",
+    "start": 68500000,
+    "end": 69300000,
+    "name": "1.p31.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 21,
+    "chromosome": "chr1",
+    "start": 69300000,
+    "end": 84400000,
+    "name": "1.p31.1",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 22,
+    "chromosome": "chr1",
+    "start": 84400000,
+    "end": 87900000,
+    "name": "1.p22.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 23,
+    "chromosome": "chr1",
+    "start": 87900000,
+    "end": 91500000,
+    "name": "1.p22.2",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 24,
+    "chromosome": "chr1",
+    "start": 91500000,
+    "end": 94300000,
+    "name": "1.p22.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 25,
+    "chromosome": "chr1",
+    "start": 94300000,
+    "end": 99300000,
+    "name": "1.p21.3",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 26,
+    "chromosome": "chr1",
+    "start": 99300000,
+    "end": 101800000,
+    "name": "1.p21.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 27,
+    "chromosome": "chr1",
+    "start": 101800000,
+    "end": 106700000,
+    "name": "1.p21.1",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 28,
+    "chromosome": "chr1",
+    "start": 106700000,
+    "end": 111200000,
+    "name": "1.p13.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 29,
+    "chromosome": "chr1",
+    "start": 111200000,
+    "end": 115500000,
+    "name": "1.p13.2",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 30,
+    "chromosome": "chr1",
+    "start": 115500000,
+    "end": 117200000,
+    "name": "1.p13.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 31,
+    "chromosome": "chr1",
+    "start": 117200000,
+    "end": 120400000,
+    "name": "1.p12",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 32,
+    "chromosome": "chr1",
+    "start": 120400000,
+    "end": 121700000,
+    "name": "1.p11.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 33,
+    "chromosome": "chr1",
+    "start": 121700000,
+    "end": 123400000,
+    "name": "1.p11.1",
+    "giemsaStains": "acen"
+  },
+  {
+    "id": 34,
+    "chromosome": "chr1",
+    "start": 123400000,
+    "end": 125100000,
+    "name": "1.q11",
+    "giemsaStains": "acen"
+  },
+  {
+    "id": 35,
+    "chromosome": "chr1",
+    "start": 125100000,
+    "end": 143200000,
+    "name": "1.q12",
+    "giemsaStains": "gvar"
+  },
+  {
+    "id": 36,
+    "chromosome": "chr1",
+    "start": 143200000,
+    "end": 147500000,
+    "name": "1.q21.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 37,
+    "chromosome": "chr1",
+    "start": 147500000,
+    "end": 150600000,
+    "name": "1.q21.2",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 38,
+    "chromosome": "chr1",
+    "start": 150600000,
+    "end": 155100000,
+    "name": "1.q21.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 39,
+    "chromosome": "chr1",
+    "start": 155100000,
+    "end": 156600000,
+    "name": "1.q22",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 40,
+    "chromosome": "chr1",
+    "start": 156600000,
+    "end": 159100000,
+    "name": "1.q23.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 41,
+    "chromosome": "chr1",
+    "start": 159100000,
+    "end": 160500000,
+    "name": "1.q23.2",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 42,
+    "chromosome": "chr1",
+    "start": 160500000,
+    "end": 165500000,
+    "name": "1.q23.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 43,
+    "chromosome": "chr1",
+    "start": 165500000,
+    "end": 167200000,
+    "name": "1.q24.1",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 44,
+    "chromosome": "chr1",
+    "start": 167200000,
+    "end": 170900000,
+    "name": "1.q24.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 45,
+    "chromosome": "chr1",
+    "start": 170900000,
+    "end": 173000000,
+    "name": "1.q24.3",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 46,
+    "chromosome": "chr1",
+    "start": 173000000,
+    "end": 176100000,
+    "name": "1.q25.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 47,
+    "chromosome": "chr1",
+    "start": 176100000,
+    "end": 180300000,
+    "name": "1.q25.2",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 48,
+    "chromosome": "chr1",
+    "start": 180300000,
+    "end": 185800000,
+    "name": "1.q25.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 49,
+    "chromosome": "chr1",
+    "start": 185800000,
+    "end": 190800000,
+    "name": "1.q31.1",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 50,
+    "chromosome": "chr1",
+    "start": 190800000,
+    "end": 193800000,
+    "name": "1.q31.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 51,
+    "chromosome": "chr1",
+    "start": 193800000,
+    "end": 198700000,
+    "name": "1.q31.3",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 52,
+    "chromosome": "chr1",
+    "start": 198700000,
+    "end": 207100000,
+    "name": "1.q32.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 53,
+    "chromosome": "chr1",
+    "start": 207100000,
+    "end": 211300000,
+    "name": "1.q32.2",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 54,
+    "chromosome": "chr1",
+    "start": 211300000,
+    "end": 214400000,
+    "name": "1.q32.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 55,
+    "chromosome": "chr1",
+    "start": 214400000,
+    "end": 223900000,
+    "name": "1.q41",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 56,
+    "chromosome": "chr1",
+    "start": 223900000,
+    "end": 224400000,
+    "name": "1.q42.11",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 57,
+    "chromosome": "chr1",
+    "start": 224400000,
+    "end": 226800000,
+    "name": "1.q42.12",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 58,
+    "chromosome": "chr1",
+    "start": 226800000,
+    "end": 230500000,
+    "name": "1.q42.13",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 59,
+    "chromosome": "chr1",
+    "start": 230500000,
+    "end": 234600000,
+    "name": "1.q42.2",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 60,
+    "chromosome": "chr1",
+    "start": 234600000,
+    "end": 236400000,
+    "name": "1.q42.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 61,
+    "chromosome": "chr1",
+    "start": 236400000,
+    "end": 243500000,
+    "name": "1.q43",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 62,
+    "chromosome": "chr1",
+    "start": 243500000,
+    "end": 248956422,
+    "name": "1.q44",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 63,
+    "chromosome": "chr2",
+    "start": 0,
+    "end": 4400000,
+    "name": "2.p25.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 64,
+    "chromosome": "chr2",
+    "start": 4400000,
+    "end": 6900000,
+    "name": "2.p25.2",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 65,
+    "chromosome": "chr2",
+    "start": 6900000,
+    "end": 12000000,
+    "name": "2.p25.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 66,
+    "chromosome": "chr2",
+    "start": 12000000,
+    "end": 16500000,
+    "name": "2.p24.3",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 67,
+    "chromosome": "chr2",
+    "start": 16500000,
+    "end": 19000000,
+    "name": "2.p24.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 68,
+    "chromosome": "chr2",
+    "start": 19000000,
+    "end": 23800000,
+    "name": "2.p24.1",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 69,
+    "chromosome": "chr2",
+    "start": 23800000,
+    "end": 27700000,
+    "name": "2.p23.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 70,
+    "chromosome": "chr2",
+    "start": 27700000,
+    "end": 29800000,
+    "name": "2.p23.2",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 71,
+    "chromosome": "chr2",
+    "start": 29800000,
+    "end": 31800000,
+    "name": "2.p23.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 72,
+    "chromosome": "chr2",
+    "start": 31800000,
+    "end": 36300000,
+    "name": "2.p22.3",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 73,
+    "chromosome": "chr2",
+    "start": 36300000,
+    "end": 38300000,
+    "name": "2.p22.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 74,
+    "chromosome": "chr2",
+    "start": 38300000,
+    "end": 41500000,
+    "name": "2.p22.1",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 75,
+    "chromosome": "chr2",
+    "start": 41500000,
+    "end": 47500000,
+    "name": "2.p21",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 76,
+    "chromosome": "chr2",
+    "start": 47500000,
+    "end": 52600000,
+    "name": "2.p16.3",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 77,
+    "chromosome": "chr2",
+    "start": 52600000,
+    "end": 54700000,
+    "name": "2.p16.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 78,
+    "chromosome": "chr2",
+    "start": 54700000,
+    "end": 61000000,
+    "name": "2.p16.1",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 79,
+    "chromosome": "chr2",
+    "start": 61000000,
+    "end": 63900000,
+    "name": "2.p15",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 80,
+    "chromosome": "chr2",
+    "start": 63900000,
+    "end": 68400000,
+    "name": "2.p14",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 81,
+    "chromosome": "chr2",
+    "start": 68400000,
+    "end": 71300000,
+    "name": "2.p13.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 82,
+    "chromosome": "chr2",
+    "start": 71300000,
+    "end": 73300000,
+    "name": "2.p13.2",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 83,
+    "chromosome": "chr2",
+    "start": 73300000,
+    "end": 74800000,
+    "name": "2.p13.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 84,
+    "chromosome": "chr2",
+    "start": 74800000,
+    "end": 83100000,
+    "name": "2.p12",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 85,
+    "chromosome": "chr2",
+    "start": 83100000,
+    "end": 91800000,
+    "name": "2.p11.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 86,
+    "chromosome": "chr2",
+    "start": 91800000,
+    "end": 93900000,
+    "name": "2.p11.1",
+    "giemsaStains": "acen"
+  },
+  {
+    "id": 87,
+    "chromosome": "chr2",
+    "start": 93900000,
+    "end": 96000000,
+    "name": "2.q11.1",
+    "giemsaStains": "acen"
+  },
+  {
+    "id": 88,
+    "chromosome": "chr2",
+    "start": 96000000,
+    "end": 102100000,
+    "name": "2.q11.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 89,
+    "chromosome": "chr2",
+    "start": 102100000,
+    "end": 105300000,
+    "name": "2.q12.1",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 90,
+    "chromosome": "chr2",
+    "start": 105300000,
+    "end": 106700000,
+    "name": "2.q12.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 91,
+    "chromosome": "chr2",
+    "start": 106700000,
+    "end": 108700000,
+    "name": "2.q12.3",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 92,
+    "chromosome": "chr2",
+    "start": 108700000,
+    "end": 112200000,
+    "name": "2.q13",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 93,
+    "chromosome": "chr2",
+    "start": 112200000,
+    "end": 118100000,
+    "name": "2.q14.1",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 94,
+    "chromosome": "chr2",
+    "start": 118100000,
+    "end": 121600000,
+    "name": "2.q14.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 95,
+    "chromosome": "chr2",
+    "start": 121600000,
+    "end": 129100000,
+    "name": "2.q14.3",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 96,
+    "chromosome": "chr2",
+    "start": 129100000,
+    "end": 131700000,
+    "name": "2.q21.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 97,
+    "chromosome": "chr2",
+    "start": 131700000,
+    "end": 134300000,
+    "name": "2.q21.2",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 98,
+    "chromosome": "chr2",
+    "start": 134300000,
+    "end": 136100000,
+    "name": "2.q21.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 99,
+    "chromosome": "chr2",
+    "start": 136100000,
+    "end": 141500000,
+    "name": "2.q22.1",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 100,
+    "chromosome": "chr2",
+    "start": 141500000,
+    "end": 143400000,
+    "name": "2.q22.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 101,
+    "chromosome": "chr2",
+    "start": 143400000,
+    "end": 147900000,
+    "name": "2.q22.3",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 102,
+    "chromosome": "chr2",
+    "start": 147900000,
+    "end": 149000000,
+    "name": "2.q23.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 103,
+    "chromosome": "chr2",
+    "start": 149000000,
+    "end": 149600000,
+    "name": "2.q23.2",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 104,
+    "chromosome": "chr2",
+    "start": 149600000,
+    "end": 154000000,
+    "name": "2.q23.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 105,
+    "chromosome": "chr2",
+    "start": 154000000,
+    "end": 158900000,
+    "name": "2.q24.1",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 106,
+    "chromosome": "chr2",
+    "start": 158900000,
+    "end": 162900000,
+    "name": "2.q24.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 107,
+    "chromosome": "chr2",
+    "start": 162900000,
+    "end": 168900000,
+    "name": "2.q24.3",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 108,
+    "chromosome": "chr2",
+    "start": 168900000,
+    "end": 177100000,
+    "name": "2.q31.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 109,
+    "chromosome": "chr2",
+    "start": 177100000,
+    "end": 179700000,
+    "name": "2.q31.2",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 110,
+    "chromosome": "chr2",
+    "start": 179700000,
+    "end": 182100000,
+    "name": "2.q31.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 111,
+    "chromosome": "chr2",
+    "start": 182100000,
+    "end": 188500000,
+    "name": "2.q32.1",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 112,
+    "chromosome": "chr2",
+    "start": 188500000,
+    "end": 191100000,
+    "name": "2.q32.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 113,
+    "chromosome": "chr2",
+    "start": 191100000,
+    "end": 196600000,
+    "name": "2.q32.3",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 114,
+    "chromosome": "chr2",
+    "start": 196600000,
+    "end": 202500000,
+    "name": "2.q33.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 115,
+    "chromosome": "chr2",
+    "start": 202500000,
+    "end": 204100000,
+    "name": "2.q33.2",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 116,
+    "chromosome": "chr2",
+    "start": 204100000,
+    "end": 208200000,
+    "name": "2.q33.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 117,
+    "chromosome": "chr2",
+    "start": 208200000,
+    "end": 214500000,
+    "name": "2.q34",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 118,
+    "chromosome": "chr2",
+    "start": 214500000,
+    "end": 220700000,
+    "name": "2.q35",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 119,
+    "chromosome": "chr2",
+    "start": 220700000,
+    "end": 224300000,
+    "name": "2.q36.1",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 120,
+    "chromosome": "chr2",
+    "start": 224300000,
+    "end": 225200000,
+    "name": "2.q36.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 121,
+    "chromosome": "chr2",
+    "start": 225200000,
+    "end": 230100000,
+    "name": "2.q36.3",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 122,
+    "chromosome": "chr2",
+    "start": 230100000,
+    "end": 234700000,
+    "name": "2.q37.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 123,
+    "chromosome": "chr2",
+    "start": 234700000,
+    "end": 236400000,
+    "name": "2.q37.2",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 124,
+    "chromosome": "chr2",
+    "start": 236400000,
+    "end": 242193529,
+    "name": "2.q37.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 125,
+    "chromosome": "chr3",
+    "start": 0,
+    "end": 2800000,
+    "name": "3.p26.3",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 126,
+    "chromosome": "chr3",
+    "start": 2800000,
+    "end": 4000000,
+    "name": "3.p26.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 127,
+    "chromosome": "chr3",
+    "start": 4000000,
+    "end": 8100000,
+    "name": "3.p26.1",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 128,
+    "chromosome": "chr3",
+    "start": 8100000,
+    "end": 11600000,
+    "name": "3.p25.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 129,
+    "chromosome": "chr3",
+    "start": 11600000,
+    "end": 13200000,
+    "name": "3.p25.2",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 130,
+    "chromosome": "chr3",
+    "start": 13200000,
+    "end": 16300000,
+    "name": "3.p25.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 131,
+    "chromosome": "chr3",
+    "start": 16300000,
+    "end": 23800000,
+    "name": "3.p24.3",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 132,
+    "chromosome": "chr3",
+    "start": 23800000,
+    "end": 26300000,
+    "name": "3.p24.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 133,
+    "chromosome": "chr3",
+    "start": 26300000,
+    "end": 30800000,
+    "name": "3.p24.1",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 134,
+    "chromosome": "chr3",
+    "start": 30800000,
+    "end": 32000000,
+    "name": "3.p23",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 135,
+    "chromosome": "chr3",
+    "start": 32000000,
+    "end": 36400000,
+    "name": "3.p22.3",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 136,
+    "chromosome": "chr3",
+    "start": 36400000,
+    "end": 39300000,
+    "name": "3.p22.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 137,
+    "chromosome": "chr3",
+    "start": 39300000,
+    "end": 43600000,
+    "name": "3.p22.1",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 138,
+    "chromosome": "chr3",
+    "start": 43600000,
+    "end": 44100000,
+    "name": "3.p21.33",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 139,
+    "chromosome": "chr3",
+    "start": 44100000,
+    "end": 44200000,
+    "name": "3.p21.32",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 140,
+    "chromosome": "chr3",
+    "start": 44200000,
+    "end": 50600000,
+    "name": "3.p21.31",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 141,
+    "chromosome": "chr3",
+    "start": 50600000,
+    "end": 52300000,
+    "name": "3.p21.2",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 142,
+    "chromosome": "chr3",
+    "start": 52300000,
+    "end": 54400000,
+    "name": "3.p21.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 143,
+    "chromosome": "chr3",
+    "start": 54400000,
+    "end": 58600000,
+    "name": "3.p14.3",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 144,
+    "chromosome": "chr3",
+    "start": 58600000,
+    "end": 63800000,
+    "name": "3.p14.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 145,
+    "chromosome": "chr3",
+    "start": 63800000,
+    "end": 69700000,
+    "name": "3.p14.1",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 146,
+    "chromosome": "chr3",
+    "start": 69700000,
+    "end": 74100000,
+    "name": "3.p13",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 147,
+    "chromosome": "chr3",
+    "start": 74100000,
+    "end": 79800000,
+    "name": "3.p12.3",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 148,
+    "chromosome": "chr3",
+    "start": 79800000,
+    "end": 83500000,
+    "name": "3.p12.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 149,
+    "chromosome": "chr3",
+    "start": 83500000,
+    "end": 87100000,
+    "name": "3.p12.1",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 150,
+    "chromosome": "chr3",
+    "start": 87100000,
+    "end": 87800000,
+    "name": "3.p11.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 151,
+    "chromosome": "chr3",
+    "start": 87800000,
+    "end": 90900000,
+    "name": "3.p11.1",
+    "giemsaStains": "acen"
+  },
+  {
+    "id": 152,
+    "chromosome": "chr3",
+    "start": 90900000,
+    "end": 94000000,
+    "name": "3.q11.1",
+    "giemsaStains": "acen"
+  },
+  {
+    "id": 153,
+    "chromosome": "chr3",
+    "start": 94000000,
+    "end": 98600000,
+    "name": "3.q11.2",
+    "giemsaStains": "gvar"
+  },
+  {
+    "id": 154,
+    "chromosome": "chr3",
+    "start": 98600000,
+    "end": 100300000,
+    "name": "3.q12.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 155,
+    "chromosome": "chr3",
+    "start": 100300000,
+    "end": 101200000,
+    "name": "3.q12.2",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 156,
+    "chromosome": "chr3",
+    "start": 101200000,
+    "end": 103100000,
+    "name": "3.q12.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 157,
+    "chromosome": "chr3",
+    "start": 103100000,
+    "end": 106500000,
+    "name": "3.q13.11",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 158,
+    "chromosome": "chr3",
+    "start": 106500000,
+    "end": 108200000,
+    "name": "3.q13.12",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 159,
+    "chromosome": "chr3",
+    "start": 108200000,
+    "end": 111600000,
+    "name": "3.q13.13",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 160,
+    "chromosome": "chr3",
+    "start": 111600000,
+    "end": 113700000,
+    "name": "3.q13.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 161,
+    "chromosome": "chr3",
+    "start": 113700000,
+    "end": 117600000,
+    "name": "3.q13.31",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 162,
+    "chromosome": "chr3",
+    "start": 117600000,
+    "end": 119300000,
+    "name": "3.q13.32",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 163,
+    "chromosome": "chr3",
+    "start": 119300000,
+    "end": 122200000,
+    "name": "3.q13.33",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 164,
+    "chromosome": "chr3",
+    "start": 122200000,
+    "end": 124100000,
+    "name": "3.q21.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 165,
+    "chromosome": "chr3",
+    "start": 124100000,
+    "end": 126100000,
+    "name": "3.q21.2",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 166,
+    "chromosome": "chr3",
+    "start": 126100000,
+    "end": 129500000,
+    "name": "3.q21.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 167,
+    "chromosome": "chr3",
+    "start": 129500000,
+    "end": 134000000,
+    "name": "3.q22.1",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 168,
+    "chromosome": "chr3",
+    "start": 134000000,
+    "end": 136000000,
+    "name": "3.q22.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 169,
+    "chromosome": "chr3",
+    "start": 136000000,
+    "end": 139000000,
+    "name": "3.q22.3",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 170,
+    "chromosome": "chr3",
+    "start": 139000000,
+    "end": 143100000,
+    "name": "3.q23",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 171,
+    "chromosome": "chr3",
+    "start": 143100000,
+    "end": 149200000,
+    "name": "3.q24",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 172,
+    "chromosome": "chr3",
+    "start": 149200000,
+    "end": 152300000,
+    "name": "3.q25.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 173,
+    "chromosome": "chr3",
+    "start": 152300000,
+    "end": 155300000,
+    "name": "3.q25.2",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 174,
+    "chromosome": "chr3",
+    "start": 155300000,
+    "end": 157300000,
+    "name": "3.q25.31",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 175,
+    "chromosome": "chr3",
+    "start": 157300000,
+    "end": 159300000,
+    "name": "3.q25.32",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 176,
+    "chromosome": "chr3",
+    "start": 159300000,
+    "end": 161000000,
+    "name": "3.q25.33",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 177,
+    "chromosome": "chr3",
+    "start": 161000000,
+    "end": 167900000,
+    "name": "3.q26.1",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 178,
+    "chromosome": "chr3",
+    "start": 167900000,
+    "end": 171200000,
+    "name": "3.q26.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 179,
+    "chromosome": "chr3",
+    "start": 171200000,
+    "end": 176000000,
+    "name": "3.q26.31",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 180,
+    "chromosome": "chr3",
+    "start": 176000000,
+    "end": 179300000,
+    "name": "3.q26.32",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 181,
+    "chromosome": "chr3",
+    "start": 179300000,
+    "end": 183000000,
+    "name": "3.q26.33",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 182,
+    "chromosome": "chr3",
+    "start": 183000000,
+    "end": 184800000,
+    "name": "3.q27.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 183,
+    "chromosome": "chr3",
+    "start": 184800000,
+    "end": 186300000,
+    "name": "3.q27.2",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 184,
+    "chromosome": "chr3",
+    "start": 186300000,
+    "end": 188200000,
+    "name": "3.q27.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 185,
+    "chromosome": "chr3",
+    "start": 188200000,
+    "end": 192600000,
+    "name": "3.q28",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 186,
+    "chromosome": "chr3",
+    "start": 192600000,
+    "end": 198295559,
+    "name": "3.q29",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 187,
+    "chromosome": "chr4",
+    "start": 0,
+    "end": 4500000,
+    "name": "4.p16.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 188,
+    "chromosome": "chr4",
+    "start": 4500000,
+    "end": 6000000,
+    "name": "4.p16.2",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 189,
+    "chromosome": "chr4",
+    "start": 6000000,
+    "end": 11300000,
+    "name": "4.p16.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 190,
+    "chromosome": "chr4",
+    "start": 11300000,
+    "end": 15000000,
+    "name": "4.p15.33",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 191,
+    "chromosome": "chr4",
+    "start": 15000000,
+    "end": 17700000,
+    "name": "4.p15.32",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 192,
+    "chromosome": "chr4",
+    "start": 17700000,
+    "end": 21300000,
+    "name": "4.p15.31",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 193,
+    "chromosome": "chr4",
+    "start": 21300000,
+    "end": 27700000,
+    "name": "4.p15.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 194,
+    "chromosome": "chr4",
+    "start": 27700000,
+    "end": 35800000,
+    "name": "4.p15.1",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 195,
+    "chromosome": "chr4",
+    "start": 35800000,
+    "end": 41200000,
+    "name": "4.p14",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 196,
+    "chromosome": "chr4",
+    "start": 41200000,
+    "end": 44600000,
+    "name": "4.p13",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 197,
+    "chromosome": "chr4",
+    "start": 44600000,
+    "end": 48200000,
+    "name": "4.p12",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 198,
+    "chromosome": "chr4",
+    "start": 48200000,
+    "end": 50000000,
+    "name": "4.p11",
+    "giemsaStains": "acen"
+  },
+  {
+    "id": 199,
+    "chromosome": "chr4",
+    "start": 50000000,
+    "end": 51800000,
+    "name": "4.q11",
+    "giemsaStains": "acen"
+  },
+  {
+    "id": 200,
+    "chromosome": "chr4",
+    "start": 51800000,
+    "end": 58500000,
+    "name": "4.q12",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 201,
+    "chromosome": "chr4",
+    "start": 58500000,
+    "end": 65500000,
+    "name": "4.q13.1",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 202,
+    "chromosome": "chr4",
+    "start": 65500000,
+    "end": 69400000,
+    "name": "4.q13.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 203,
+    "chromosome": "chr4",
+    "start": 69400000,
+    "end": 75300000,
+    "name": "4.q13.3",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 204,
+    "chromosome": "chr4",
+    "start": 75300000,
+    "end": 78000000,
+    "name": "4.q21.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 205,
+    "chromosome": "chr4",
+    "start": 78000000,
+    "end": 81500000,
+    "name": "4.q21.21",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 206,
+    "chromosome": "chr4",
+    "start": 81500000,
+    "end": 83200000,
+    "name": "4.q21.22",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 207,
+    "chromosome": "chr4",
+    "start": 83200000,
+    "end": 86000000,
+    "name": "4.q21.23",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 208,
+    "chromosome": "chr4",
+    "start": 86000000,
+    "end": 87100000,
+    "name": "4.q21.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 209,
+    "chromosome": "chr4",
+    "start": 87100000,
+    "end": 92800000,
+    "name": "4.q22.1",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 210,
+    "chromosome": "chr4",
+    "start": 92800000,
+    "end": 94200000,
+    "name": "4.q22.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 211,
+    "chromosome": "chr4",
+    "start": 94200000,
+    "end": 97900000,
+    "name": "4.q22.3",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 212,
+    "chromosome": "chr4",
+    "start": 97900000,
+    "end": 100100000,
+    "name": "4.q23",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 213,
+    "chromosome": "chr4",
+    "start": 100100000,
+    "end": 106700000,
+    "name": "4.q24",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 214,
+    "chromosome": "chr4",
+    "start": 106700000,
+    "end": 113200000,
+    "name": "4.q25",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 215,
+    "chromosome": "chr4",
+    "start": 113200000,
+    "end": 119900000,
+    "name": "4.q26",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 216,
+    "chromosome": "chr4",
+    "start": 119900000,
+    "end": 122800000,
+    "name": "4.q27",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 217,
+    "chromosome": "chr4",
+    "start": 122800000,
+    "end": 127900000,
+    "name": "4.q28.1",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 218,
+    "chromosome": "chr4",
+    "start": 127900000,
+    "end": 130100000,
+    "name": "4.q28.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 219,
+    "chromosome": "chr4",
+    "start": 130100000,
+    "end": 138500000,
+    "name": "4.q28.3",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 220,
+    "chromosome": "chr4",
+    "start": 138500000,
+    "end": 140600000,
+    "name": "4.q31.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 221,
+    "chromosome": "chr4",
+    "start": 140600000,
+    "end": 145900000,
+    "name": "4.q31.21",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 222,
+    "chromosome": "chr4",
+    "start": 145900000,
+    "end": 147500000,
+    "name": "4.q31.22",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 223,
+    "chromosome": "chr4",
+    "start": 147500000,
+    "end": 150200000,
+    "name": "4.q31.23",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 224,
+    "chromosome": "chr4",
+    "start": 150200000,
+    "end": 154600000,
+    "name": "4.q31.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 225,
+    "chromosome": "chr4",
+    "start": 154600000,
+    "end": 160800000,
+    "name": "4.q32.1",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 226,
+    "chromosome": "chr4",
+    "start": 160800000,
+    "end": 163600000,
+    "name": "4.q32.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 227,
+    "chromosome": "chr4",
+    "start": 163600000,
+    "end": 169200000,
+    "name": "4.q32.3",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 228,
+    "chromosome": "chr4",
+    "start": 169200000,
+    "end": 171000000,
+    "name": "4.q33",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 229,
+    "chromosome": "chr4",
+    "start": 171000000,
+    "end": 175400000,
+    "name": "4.q34.1",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 230,
+    "chromosome": "chr4",
+    "start": 175400000,
+    "end": 176600000,
+    "name": "4.q34.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 231,
+    "chromosome": "chr4",
+    "start": 176600000,
+    "end": 182300000,
+    "name": "4.q34.3",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 232,
+    "chromosome": "chr4",
+    "start": 182300000,
+    "end": 186200000,
+    "name": "4.q35.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 233,
+    "chromosome": "chr4",
+    "start": 186200000,
+    "end": 190214555,
+    "name": "4.q35.2",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 234,
+    "chromosome": "chr5",
+    "start": 0,
+    "end": 4400000,
+    "name": "5.p15.33",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 235,
+    "chromosome": "chr5",
+    "start": 4400000,
+    "end": 6300000,
+    "name": "5.p15.32",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 236,
+    "chromosome": "chr5",
+    "start": 6300000,
+    "end": 9900000,
+    "name": "5.p15.31",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 237,
+    "chromosome": "chr5",
+    "start": 9900000,
+    "end": 15000000,
+    "name": "5.p15.2",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 238,
+    "chromosome": "chr5",
+    "start": 15000000,
+    "end": 18400000,
+    "name": "5.p15.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 239,
+    "chromosome": "chr5",
+    "start": 18400000,
+    "end": 23300000,
+    "name": "5.p14.3",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 240,
+    "chromosome": "chr5",
+    "start": 23300000,
+    "end": 24600000,
+    "name": "5.p14.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 241,
+    "chromosome": "chr5",
+    "start": 24600000,
+    "end": 28900000,
+    "name": "5.p14.1",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 242,
+    "chromosome": "chr5",
+    "start": 28900000,
+    "end": 33800000,
+    "name": "5.p13.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 243,
+    "chromosome": "chr5",
+    "start": 33800000,
+    "end": 38400000,
+    "name": "5.p13.2",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 244,
+    "chromosome": "chr5",
+    "start": 38400000,
+    "end": 42500000,
+    "name": "5.p13.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 245,
+    "chromosome": "chr5",
+    "start": 42500000,
+    "end": 46100000,
+    "name": "5.p12",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 246,
+    "chromosome": "chr5",
+    "start": 46100000,
+    "end": 48800000,
+    "name": "5.p11",
+    "giemsaStains": "acen"
+  },
+  {
+    "id": 247,
+    "chromosome": "chr5",
+    "start": 48800000,
+    "end": 51400000,
+    "name": "5.q11.1",
+    "giemsaStains": "acen"
+  },
+  {
+    "id": 248,
+    "chromosome": "chr5",
+    "start": 51400000,
+    "end": 59600000,
+    "name": "5.q11.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 249,
+    "chromosome": "chr5",
+    "start": 59600000,
+    "end": 63600000,
+    "name": "5.q12.1",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 250,
+    "chromosome": "chr5",
+    "start": 63600000,
+    "end": 63900000,
+    "name": "5.q12.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 251,
+    "chromosome": "chr5",
+    "start": 63900000,
+    "end": 67400000,
+    "name": "5.q12.3",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 252,
+    "chromosome": "chr5",
+    "start": 67400000,
+    "end": 69100000,
+    "name": "5.q13.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 253,
+    "chromosome": "chr5",
+    "start": 69100000,
+    "end": 74000000,
+    "name": "5.q13.2",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 254,
+    "chromosome": "chr5",
+    "start": 74000000,
+    "end": 77600000,
+    "name": "5.q13.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 255,
+    "chromosome": "chr5",
+    "start": 77600000,
+    "end": 82100000,
+    "name": "5.q14.1",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 256,
+    "chromosome": "chr5",
+    "start": 82100000,
+    "end": 83500000,
+    "name": "5.q14.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 257,
+    "chromosome": "chr5",
+    "start": 83500000,
+    "end": 93000000,
+    "name": "5.q14.3",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 258,
+    "chromosome": "chr5",
+    "start": 93000000,
+    "end": 98900000,
+    "name": "5.q15",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 259,
+    "chromosome": "chr5",
+    "start": 98900000,
+    "end": 103400000,
+    "name": "5.q21.1",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 260,
+    "chromosome": "chr5",
+    "start": 103400000,
+    "end": 105100000,
+    "name": "5.q21.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 261,
+    "chromosome": "chr5",
+    "start": 105100000,
+    "end": 110200000,
+    "name": "5.q21.3",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 262,
+    "chromosome": "chr5",
+    "start": 110200000,
+    "end": 112200000,
+    "name": "5.q22.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 263,
+    "chromosome": "chr5",
+    "start": 112200000,
+    "end": 113800000,
+    "name": "5.q22.2",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 264,
+    "chromosome": "chr5",
+    "start": 113800000,
+    "end": 115900000,
+    "name": "5.q22.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 265,
+    "chromosome": "chr5",
+    "start": 115900000,
+    "end": 122100000,
+    "name": "5.q23.1",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 266,
+    "chromosome": "chr5",
+    "start": 122100000,
+    "end": 127900000,
+    "name": "5.q23.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 267,
+    "chromosome": "chr5",
+    "start": 127900000,
+    "end": 131200000,
+    "name": "5.q23.3",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 268,
+    "chromosome": "chr5",
+    "start": 131200000,
+    "end": 136900000,
+    "name": "5.q31.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 269,
+    "chromosome": "chr5",
+    "start": 136900000,
+    "end": 140100000,
+    "name": "5.q31.2",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 270,
+    "chromosome": "chr5",
+    "start": 140100000,
+    "end": 145100000,
+    "name": "5.q31.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 271,
+    "chromosome": "chr5",
+    "start": 145100000,
+    "end": 150400000,
+    "name": "5.q32",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 272,
+    "chromosome": "chr5",
+    "start": 150400000,
+    "end": 153300000,
+    "name": "5.q33.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 273,
+    "chromosome": "chr5",
+    "start": 153300000,
+    "end": 156300000,
+    "name": "5.q33.2",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 274,
+    "chromosome": "chr5",
+    "start": 156300000,
+    "end": 160500000,
+    "name": "5.q33.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 275,
+    "chromosome": "chr5",
+    "start": 160500000,
+    "end": 169000000,
+    "name": "5.q34",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 276,
+    "chromosome": "chr5",
+    "start": 169000000,
+    "end": 173300000,
+    "name": "5.q35.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 277,
+    "chromosome": "chr5",
+    "start": 173300000,
+    "end": 177100000,
+    "name": "5.q35.2",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 278,
+    "chromosome": "chr5",
+    "start": 177100000,
+    "end": 181538259,
+    "name": "5.q35.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 279,
+    "chromosome": "chr6",
+    "start": 0,
+    "end": 2300000,
+    "name": "6.p25.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 280,
+    "chromosome": "chr6",
+    "start": 2300000,
+    "end": 4200000,
+    "name": "6.p25.2",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 281,
+    "chromosome": "chr6",
+    "start": 4200000,
+    "end": 7100000,
+    "name": "6.p25.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 282,
+    "chromosome": "chr6",
+    "start": 7100000,
+    "end": 10600000,
+    "name": "6.p24.3",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 283,
+    "chromosome": "chr6",
+    "start": 10600000,
+    "end": 11600000,
+    "name": "6.p24.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 284,
+    "chromosome": "chr6",
+    "start": 11600000,
+    "end": 13400000,
+    "name": "6.p24.1",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 285,
+    "chromosome": "chr6",
+    "start": 13400000,
+    "end": 15200000,
+    "name": "6.p23",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 286,
+    "chromosome": "chr6",
+    "start": 15200000,
+    "end": 25200000,
+    "name": "6.p22.3",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 287,
+    "chromosome": "chr6",
+    "start": 25200000,
+    "end": 27100000,
+    "name": "6.p22.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 288,
+    "chromosome": "chr6",
+    "start": 27100000,
+    "end": 30500000,
+    "name": "6.p22.1",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 289,
+    "chromosome": "chr6",
+    "start": 30500000,
+    "end": 32100000,
+    "name": "6.p21.33",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 290,
+    "chromosome": "chr6",
+    "start": 32100000,
+    "end": 33500000,
+    "name": "6.p21.32",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 291,
+    "chromosome": "chr6",
+    "start": 33500000,
+    "end": 36600000,
+    "name": "6.p21.31",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 292,
+    "chromosome": "chr6",
+    "start": 36600000,
+    "end": 40500000,
+    "name": "6.p21.2",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 293,
+    "chromosome": "chr6",
+    "start": 40500000,
+    "end": 46200000,
+    "name": "6.p21.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 294,
+    "chromosome": "chr6",
+    "start": 46200000,
+    "end": 51800000,
+    "name": "6.p12.3",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 295,
+    "chromosome": "chr6",
+    "start": 51800000,
+    "end": 53000000,
+    "name": "6.p12.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 296,
+    "chromosome": "chr6",
+    "start": 53000000,
+    "end": 57200000,
+    "name": "6.p12.1",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 297,
+    "chromosome": "chr6",
+    "start": 57200000,
+    "end": 58500000,
+    "name": "6.p11.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 298,
+    "chromosome": "chr6",
+    "start": 58500000,
+    "end": 59800000,
+    "name": "6.p11.1",
+    "giemsaStains": "acen"
+  },
+  {
+    "id": 299,
+    "chromosome": "chr6",
+    "start": 59800000,
+    "end": 62600000,
+    "name": "6.q11.1",
+    "giemsaStains": "acen"
+  },
+  {
+    "id": 300,
+    "chromosome": "chr6",
+    "start": 62600000,
+    "end": 62700000,
+    "name": "6.q11.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 301,
+    "chromosome": "chr6",
+    "start": 62700000,
+    "end": 69200000,
+    "name": "6.q12",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 302,
+    "chromosome": "chr6",
+    "start": 69200000,
+    "end": 75200000,
+    "name": "6.q13",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 303,
+    "chromosome": "chr6",
+    "start": 75200000,
+    "end": 83200000,
+    "name": "6.q14.1",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 304,
+    "chromosome": "chr6",
+    "start": 83200000,
+    "end": 84200000,
+    "name": "6.q14.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 305,
+    "chromosome": "chr6",
+    "start": 84200000,
+    "end": 87300000,
+    "name": "6.q14.3",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 306,
+    "chromosome": "chr6",
+    "start": 87300000,
+    "end": 92500000,
+    "name": "6.q15",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 307,
+    "chromosome": "chr6",
+    "start": 92500000,
+    "end": 98900000,
+    "name": "6.q16.1",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 308,
+    "chromosome": "chr6",
+    "start": 98900000,
+    "end": 100000000,
+    "name": "6.q16.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 309,
+    "chromosome": "chr6",
+    "start": 100000000,
+    "end": 105000000,
+    "name": "6.q16.3",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 310,
+    "chromosome": "chr6",
+    "start": 105000000,
+    "end": 114200000,
+    "name": "6.q21",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 311,
+    "chromosome": "chr6",
+    "start": 114200000,
+    "end": 117900000,
+    "name": "6.q22.1",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 312,
+    "chromosome": "chr6",
+    "start": 117900000,
+    "end": 118100000,
+    "name": "6.q22.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 313,
+    "chromosome": "chr6",
+    "start": 118100000,
+    "end": 125800000,
+    "name": "6.q22.31",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 314,
+    "chromosome": "chr6",
+    "start": 125800000,
+    "end": 126800000,
+    "name": "6.q22.32",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 315,
+    "chromosome": "chr6",
+    "start": 126800000,
+    "end": 130000000,
+    "name": "6.q22.33",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 316,
+    "chromosome": "chr6",
+    "start": 130000000,
+    "end": 130900000,
+    "name": "6.q23.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 317,
+    "chromosome": "chr6",
+    "start": 130900000,
+    "end": 134700000,
+    "name": "6.q23.2",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 318,
+    "chromosome": "chr6",
+    "start": 134700000,
+    "end": 138300000,
+    "name": "6.q23.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 319,
+    "chromosome": "chr6",
+    "start": 138300000,
+    "end": 142200000,
+    "name": "6.q24.1",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 320,
+    "chromosome": "chr6",
+    "start": 142200000,
+    "end": 145100000,
+    "name": "6.q24.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 321,
+    "chromosome": "chr6",
+    "start": 145100000,
+    "end": 148500000,
+    "name": "6.q24.3",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 322,
+    "chromosome": "chr6",
+    "start": 148500000,
+    "end": 152100000,
+    "name": "6.q25.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 323,
+    "chromosome": "chr6",
+    "start": 152100000,
+    "end": 155200000,
+    "name": "6.q25.2",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 324,
+    "chromosome": "chr6",
+    "start": 155200000,
+    "end": 160600000,
+    "name": "6.q25.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 325,
+    "chromosome": "chr6",
+    "start": 160600000,
+    "end": 164100000,
+    "name": "6.q26",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 326,
+    "chromosome": "chr6",
+    "start": 164100000,
+    "end": 170805979,
+    "name": "6.q27",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 327,
+    "chromosome": "chr7",
+    "start": 0,
+    "end": 2800000,
+    "name": "7.p22.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 328,
+    "chromosome": "chr7",
+    "start": 2800000,
+    "end": 4500000,
+    "name": "7.p22.2",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 329,
+    "chromosome": "chr7",
+    "start": 4500000,
+    "end": 7200000,
+    "name": "7.p22.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 330,
+    "chromosome": "chr7",
+    "start": 7200000,
+    "end": 13700000,
+    "name": "7.p21.3",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 331,
+    "chromosome": "chr7",
+    "start": 13700000,
+    "end": 16500000,
+    "name": "7.p21.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 332,
+    "chromosome": "chr7",
+    "start": 16500000,
+    "end": 20900000,
+    "name": "7.p21.1",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 333,
+    "chromosome": "chr7",
+    "start": 20900000,
+    "end": 25500000,
+    "name": "7.p15.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 334,
+    "chromosome": "chr7",
+    "start": 25500000,
+    "end": 27900000,
+    "name": "7.p15.2",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 335,
+    "chromosome": "chr7",
+    "start": 27900000,
+    "end": 28800000,
+    "name": "7.p15.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 336,
+    "chromosome": "chr7",
+    "start": 28800000,
+    "end": 34900000,
+    "name": "7.p14.3",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 337,
+    "chromosome": "chr7",
+    "start": 34900000,
+    "end": 37100000,
+    "name": "7.p14.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 338,
+    "chromosome": "chr7",
+    "start": 37100000,
+    "end": 43300000,
+    "name": "7.p14.1",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 339,
+    "chromosome": "chr7",
+    "start": 43300000,
+    "end": 45400000,
+    "name": "7.p13",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 340,
+    "chromosome": "chr7",
+    "start": 45400000,
+    "end": 49000000,
+    "name": "7.p12.3",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 341,
+    "chromosome": "chr7",
+    "start": 49000000,
+    "end": 50500000,
+    "name": "7.p12.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 342,
+    "chromosome": "chr7",
+    "start": 50500000,
+    "end": 53900000,
+    "name": "7.p12.1",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 343,
+    "chromosome": "chr7",
+    "start": 53900000,
+    "end": 58100000,
+    "name": "7.p11.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 344,
+    "chromosome": "chr7",
+    "start": 58100000,
+    "end": 60100000,
+    "name": "7.p11.1",
+    "giemsaStains": "acen"
+  },
+  {
+    "id": 345,
+    "chromosome": "chr7",
+    "start": 60100000,
+    "end": 62100000,
+    "name": "7.q11.1",
+    "giemsaStains": "acen"
+  },
+  {
+    "id": 346,
+    "chromosome": "chr7",
+    "start": 62100000,
+    "end": 67500000,
+    "name": "7.q11.21",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 347,
+    "chromosome": "chr7",
+    "start": 67500000,
+    "end": 72700000,
+    "name": "7.q11.22",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 348,
+    "chromosome": "chr7",
+    "start": 72700000,
+    "end": 77900000,
+    "name": "7.q11.23",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 349,
+    "chromosome": "chr7",
+    "start": 77900000,
+    "end": 86700000,
+    "name": "7.q21.11",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 350,
+    "chromosome": "chr7",
+    "start": 86700000,
+    "end": 88500000,
+    "name": "7.q21.12",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 351,
+    "chromosome": "chr7",
+    "start": 88500000,
+    "end": 91500000,
+    "name": "7.q21.13",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 352,
+    "chromosome": "chr7",
+    "start": 91500000,
+    "end": 93300000,
+    "name": "7.q21.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 353,
+    "chromosome": "chr7",
+    "start": 93300000,
+    "end": 98400000,
+    "name": "7.q21.3",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 354,
+    "chromosome": "chr7",
+    "start": 98400000,
+    "end": 104200000,
+    "name": "7.q22.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 355,
+    "chromosome": "chr7",
+    "start": 104200000,
+    "end": 104900000,
+    "name": "7.q22.2",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 356,
+    "chromosome": "chr7",
+    "start": 104900000,
+    "end": 107800000,
+    "name": "7.q22.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 357,
+    "chromosome": "chr7",
+    "start": 107800000,
+    "end": 115000000,
+    "name": "7.q31.1",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 358,
+    "chromosome": "chr7",
+    "start": 115000000,
+    "end": 117700000,
+    "name": "7.q31.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 359,
+    "chromosome": "chr7",
+    "start": 117700000,
+    "end": 121400000,
+    "name": "7.q31.31",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 360,
+    "chromosome": "chr7",
+    "start": 121400000,
+    "end": 124100000,
+    "name": "7.q31.32",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 361,
+    "chromosome": "chr7",
+    "start": 124100000,
+    "end": 127500000,
+    "name": "7.q31.33",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 362,
+    "chromosome": "chr7",
+    "start": 127500000,
+    "end": 129600000,
+    "name": "7.q32.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 363,
+    "chromosome": "chr7",
+    "start": 129600000,
+    "end": 130800000,
+    "name": "7.q32.2",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 364,
+    "chromosome": "chr7",
+    "start": 130800000,
+    "end": 132900000,
+    "name": "7.q32.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 365,
+    "chromosome": "chr7",
+    "start": 132900000,
+    "end": 138500000,
+    "name": "7.q33",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 366,
+    "chromosome": "chr7",
+    "start": 138500000,
+    "end": 143400000,
+    "name": "7.q34",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 367,
+    "chromosome": "chr7",
+    "start": 143400000,
+    "end": 148200000,
+    "name": "7.q35",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 368,
+    "chromosome": "chr7",
+    "start": 148200000,
+    "end": 152800000,
+    "name": "7.q36.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 369,
+    "chromosome": "chr7",
+    "start": 152800000,
+    "end": 155200000,
+    "name": "7.q36.2",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 370,
+    "chromosome": "chr7",
+    "start": 155200000,
+    "end": 159345973,
+    "name": "7.q36.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 371,
+    "chromosome": "chr8",
+    "start": 0,
+    "end": 2300000,
+    "name": "8.p23.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 372,
+    "chromosome": "chr8",
+    "start": 2300000,
+    "end": 6300000,
+    "name": "8.p23.2",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 373,
+    "chromosome": "chr8",
+    "start": 6300000,
+    "end": 12800000,
+    "name": "8.p23.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 374,
+    "chromosome": "chr8",
+    "start": 12800000,
+    "end": 19200000,
+    "name": "8.p22",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 375,
+    "chromosome": "chr8",
+    "start": 19200000,
+    "end": 23500000,
+    "name": "8.p21.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 376,
+    "chromosome": "chr8",
+    "start": 23500000,
+    "end": 27500000,
+    "name": "8.p21.2",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 377,
+    "chromosome": "chr8",
+    "start": 27500000,
+    "end": 29000000,
+    "name": "8.p21.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 378,
+    "chromosome": "chr8",
+    "start": 29000000,
+    "end": 36700000,
+    "name": "8.p12",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 379,
+    "chromosome": "chr8",
+    "start": 36700000,
+    "end": 38500000,
+    "name": "8.p11.23",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 380,
+    "chromosome": "chr8",
+    "start": 38500000,
+    "end": 39900000,
+    "name": "8.p11.22",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 381,
+    "chromosome": "chr8",
+    "start": 39900000,
+    "end": 43200000,
+    "name": "8.p11.21",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 382,
+    "chromosome": "chr8",
+    "start": 43200000,
+    "end": 45200000,
+    "name": "8.p11.1",
+    "giemsaStains": "acen"
+  },
+  {
+    "id": 383,
+    "chromosome": "chr8",
+    "start": 45200000,
+    "end": 47200000,
+    "name": "8.q11.1",
+    "giemsaStains": "acen"
+  },
+  {
+    "id": 384,
+    "chromosome": "chr8",
+    "start": 47200000,
+    "end": 51300000,
+    "name": "8.q11.21",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 385,
+    "chromosome": "chr8",
+    "start": 51300000,
+    "end": 51700000,
+    "name": "8.q11.22",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 386,
+    "chromosome": "chr8",
+    "start": 51700000,
+    "end": 54600000,
+    "name": "8.q11.23",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 387,
+    "chromosome": "chr8",
+    "start": 54600000,
+    "end": 60600000,
+    "name": "8.q12.1",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 388,
+    "chromosome": "chr8",
+    "start": 60600000,
+    "end": 61300000,
+    "name": "8.q12.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 389,
+    "chromosome": "chr8",
+    "start": 61300000,
+    "end": 65100000,
+    "name": "8.q12.3",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 390,
+    "chromosome": "chr8",
+    "start": 65100000,
+    "end": 67100000,
+    "name": "8.q13.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 391,
+    "chromosome": "chr8",
+    "start": 67100000,
+    "end": 69600000,
+    "name": "8.q13.2",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 392,
+    "chromosome": "chr8",
+    "start": 69600000,
+    "end": 72000000,
+    "name": "8.q13.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 393,
+    "chromosome": "chr8",
+    "start": 72000000,
+    "end": 74600000,
+    "name": "8.q21.11",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 394,
+    "chromosome": "chr8",
+    "start": 74600000,
+    "end": 74700000,
+    "name": "8.q21.12",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 395,
+    "chromosome": "chr8",
+    "start": 74700000,
+    "end": 83500000,
+    "name": "8.q21.13",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 396,
+    "chromosome": "chr8",
+    "start": 83500000,
+    "end": 85900000,
+    "name": "8.q21.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 397,
+    "chromosome": "chr8",
+    "start": 85900000,
+    "end": 92300000,
+    "name": "8.q21.3",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 398,
+    "chromosome": "chr8",
+    "start": 92300000,
+    "end": 97900000,
+    "name": "8.q22.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 399,
+    "chromosome": "chr8",
+    "start": 97900000,
+    "end": 100500000,
+    "name": "8.q22.2",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 400,
+    "chromosome": "chr8",
+    "start": 100500000,
+    "end": 105100000,
+    "name": "8.q22.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 401,
+    "chromosome": "chr8",
+    "start": 105100000,
+    "end": 109500000,
+    "name": "8.q23.1",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 402,
+    "chromosome": "chr8",
+    "start": 109500000,
+    "end": 111100000,
+    "name": "8.q23.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 403,
+    "chromosome": "chr8",
+    "start": 111100000,
+    "end": 116700000,
+    "name": "8.q23.3",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 404,
+    "chromosome": "chr8",
+    "start": 116700000,
+    "end": 118300000,
+    "name": "8.q24.11",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 405,
+    "chromosome": "chr8",
+    "start": 118300000,
+    "end": 121500000,
+    "name": "8.q24.12",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 406,
+    "chromosome": "chr8",
+    "start": 121500000,
+    "end": 126300000,
+    "name": "8.q24.13",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 407,
+    "chromosome": "chr8",
+    "start": 126300000,
+    "end": 130400000,
+    "name": "8.q24.21",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 408,
+    "chromosome": "chr8",
+    "start": 130400000,
+    "end": 135400000,
+    "name": "8.q24.22",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 409,
+    "chromosome": "chr8",
+    "start": 135400000,
+    "end": 138900000,
+    "name": "8.q24.23",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 410,
+    "chromosome": "chr8",
+    "start": 138900000,
+    "end": 145138636,
+    "name": "8.q24.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 411,
+    "chromosome": "chr9",
+    "start": 0,
+    "end": 2200000,
+    "name": "9.p24.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 412,
+    "chromosome": "chr9",
+    "start": 2200000,
+    "end": 4600000,
+    "name": "9.p24.2",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 413,
+    "chromosome": "chr9",
+    "start": 4600000,
+    "end": 9000000,
+    "name": "9.p24.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 414,
+    "chromosome": "chr9",
+    "start": 9000000,
+    "end": 14200000,
+    "name": "9.p23",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 415,
+    "chromosome": "chr9",
+    "start": 14200000,
+    "end": 16600000,
+    "name": "9.p22.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 416,
+    "chromosome": "chr9",
+    "start": 16600000,
+    "end": 18500000,
+    "name": "9.p22.2",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 417,
+    "chromosome": "chr9",
+    "start": 18500000,
+    "end": 19900000,
+    "name": "9.p22.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 418,
+    "chromosome": "chr9",
+    "start": 19900000,
+    "end": 25600000,
+    "name": "9.p21.3",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 419,
+    "chromosome": "chr9",
+    "start": 25600000,
+    "end": 28000000,
+    "name": "9.p21.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 420,
+    "chromosome": "chr9",
+    "start": 28000000,
+    "end": 33200000,
+    "name": "9.p21.1",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 421,
+    "chromosome": "chr9",
+    "start": 33200000,
+    "end": 36300000,
+    "name": "9.p13.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 422,
+    "chromosome": "chr9",
+    "start": 36300000,
+    "end": 37900000,
+    "name": "9.p13.2",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 423,
+    "chromosome": "chr9",
+    "start": 37900000,
+    "end": 39000000,
+    "name": "9.p13.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 424,
+    "chromosome": "chr9",
+    "start": 39000000,
+    "end": 40000000,
+    "name": "9.p12",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 425,
+    "chromosome": "chr9",
+    "start": 40000000,
+    "end": 42200000,
+    "name": "9.p11.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 426,
+    "chromosome": "chr9",
+    "start": 42200000,
+    "end": 43000000,
+    "name": "9.p11.1",
+    "giemsaStains": "acen"
+  },
+  {
+    "id": 427,
+    "chromosome": "chr9",
+    "start": 43000000,
+    "end": 45500000,
+    "name": "9.q11",
+    "giemsaStains": "acen"
+  },
+  {
+    "id": 428,
+    "chromosome": "chr9",
+    "start": 45500000,
+    "end": 61500000,
+    "name": "9.q12",
+    "giemsaStains": "gvar"
+  },
+  {
+    "id": 429,
+    "chromosome": "chr9",
+    "start": 61500000,
+    "end": 65000000,
+    "name": "9.q13",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 430,
+    "chromosome": "chr9",
+    "start": 65000000,
+    "end": 69300000,
+    "name": "9.q21.11",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 431,
+    "chromosome": "chr9",
+    "start": 69300000,
+    "end": 71300000,
+    "name": "9.q21.12",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 432,
+    "chromosome": "chr9",
+    "start": 71300000,
+    "end": 76600000,
+    "name": "9.q21.13",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 433,
+    "chromosome": "chr9",
+    "start": 76600000,
+    "end": 78500000,
+    "name": "9.q21.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 434,
+    "chromosome": "chr9",
+    "start": 78500000,
+    "end": 81500000,
+    "name": "9.q21.31",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 435,
+    "chromosome": "chr9",
+    "start": 81500000,
+    "end": 84300000,
+    "name": "9.q21.32",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 436,
+    "chromosome": "chr9",
+    "start": 84300000,
+    "end": 87800000,
+    "name": "9.q21.33",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 437,
+    "chromosome": "chr9",
+    "start": 87800000,
+    "end": 89200000,
+    "name": "9.q22.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 438,
+    "chromosome": "chr9",
+    "start": 89200000,
+    "end": 91200000,
+    "name": "9.q22.2",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 439,
+    "chromosome": "chr9",
+    "start": 91200000,
+    "end": 93900000,
+    "name": "9.q22.31",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 440,
+    "chromosome": "chr9",
+    "start": 93900000,
+    "end": 96500000,
+    "name": "9.q22.32",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 441,
+    "chromosome": "chr9",
+    "start": 96500000,
+    "end": 99800000,
+    "name": "9.q22.33",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 442,
+    "chromosome": "chr9",
+    "start": 99800000,
+    "end": 105400000,
+    "name": "9.q31.1",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 443,
+    "chromosome": "chr9",
+    "start": 105400000,
+    "end": 108500000,
+    "name": "9.q31.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 444,
+    "chromosome": "chr9",
+    "start": 108500000,
+    "end": 112100000,
+    "name": "9.q31.3",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 445,
+    "chromosome": "chr9",
+    "start": 112100000,
+    "end": 114900000,
+    "name": "9.q32",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 446,
+    "chromosome": "chr9",
+    "start": 114900000,
+    "end": 119800000,
+    "name": "9.q33.1",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 447,
+    "chromosome": "chr9",
+    "start": 119800000,
+    "end": 123100000,
+    "name": "9.q33.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 448,
+    "chromosome": "chr9",
+    "start": 123100000,
+    "end": 127500000,
+    "name": "9.q33.3",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 449,
+    "chromosome": "chr9",
+    "start": 127500000,
+    "end": 130600000,
+    "name": "9.q34.11",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 450,
+    "chromosome": "chr9",
+    "start": 130600000,
+    "end": 131100000,
+    "name": "9.q34.12",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 451,
+    "chromosome": "chr9",
+    "start": 131100000,
+    "end": 133100000,
+    "name": "9.q34.13",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 452,
+    "chromosome": "chr9",
+    "start": 133100000,
+    "end": 134500000,
+    "name": "9.q34.2",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 453,
+    "chromosome": "chr9",
+    "start": 134500000,
+    "end": 138394717,
+    "name": "9.q34.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 454,
+    "chromosome": "chr10",
+    "start": 0,
+    "end": 3000000,
+    "name": "10.p15.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 455,
+    "chromosome": "chr10",
+    "start": 3000000,
+    "end": 3800000,
+    "name": "10.p15.2",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 456,
+    "chromosome": "chr10",
+    "start": 3800000,
+    "end": 6600000,
+    "name": "10.p15.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 457,
+    "chromosome": "chr10",
+    "start": 6600000,
+    "end": 12200000,
+    "name": "10.p14",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 458,
+    "chromosome": "chr10",
+    "start": 12200000,
+    "end": 17300000,
+    "name": "10.p13",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 459,
+    "chromosome": "chr10",
+    "start": 17300000,
+    "end": 18300000,
+    "name": "10.p12.33",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 460,
+    "chromosome": "chr10",
+    "start": 18300000,
+    "end": 18400000,
+    "name": "10.p12.32",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 461,
+    "chromosome": "chr10",
+    "start": 18400000,
+    "end": 22300000,
+    "name": "10.p12.31",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 462,
+    "chromosome": "chr10",
+    "start": 22300000,
+    "end": 24300000,
+    "name": "10.p12.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 463,
+    "chromosome": "chr10",
+    "start": 24300000,
+    "end": 29300000,
+    "name": "10.p12.1",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 464,
+    "chromosome": "chr10",
+    "start": 29300000,
+    "end": 31100000,
+    "name": "10.p11.23",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 465,
+    "chromosome": "chr10",
+    "start": 31100000,
+    "end": 34200000,
+    "name": "10.p11.22",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 466,
+    "chromosome": "chr10",
+    "start": 34200000,
+    "end": 38000000,
+    "name": "10.p11.21",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 467,
+    "chromosome": "chr10",
+    "start": 38000000,
+    "end": 39800000,
+    "name": "10.p11.1",
+    "giemsaStains": "acen"
+  },
+  {
+    "id": 468,
+    "chromosome": "chr10",
+    "start": 39800000,
+    "end": 41600000,
+    "name": "10.q11.1",
+    "giemsaStains": "acen"
+  },
+  {
+    "id": 469,
+    "chromosome": "chr10",
+    "start": 41600000,
+    "end": 45500000,
+    "name": "10.q11.21",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 470,
+    "chromosome": "chr10",
+    "start": 45500000,
+    "end": 48600000,
+    "name": "10.q11.22",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 471,
+    "chromosome": "chr10",
+    "start": 48600000,
+    "end": 51100000,
+    "name": "10.q11.23",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 472,
+    "chromosome": "chr10",
+    "start": 51100000,
+    "end": 59400000,
+    "name": "10.q21.1",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 473,
+    "chromosome": "chr10",
+    "start": 59400000,
+    "end": 62800000,
+    "name": "10.q21.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 474,
+    "chromosome": "chr10",
+    "start": 62800000,
+    "end": 68800000,
+    "name": "10.q21.3",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 475,
+    "chromosome": "chr10",
+    "start": 68800000,
+    "end": 73100000,
+    "name": "10.q22.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 476,
+    "chromosome": "chr10",
+    "start": 73100000,
+    "end": 75900000,
+    "name": "10.q22.2",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 477,
+    "chromosome": "chr10",
+    "start": 75900000,
+    "end": 80300000,
+    "name": "10.q22.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 478,
+    "chromosome": "chr10",
+    "start": 80300000,
+    "end": 86100000,
+    "name": "10.q23.1",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 479,
+    "chromosome": "chr10",
+    "start": 86100000,
+    "end": 87700000,
+    "name": "10.q23.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 480,
+    "chromosome": "chr10",
+    "start": 87700000,
+    "end": 91100000,
+    "name": "10.q23.31",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 481,
+    "chromosome": "chr10",
+    "start": 91100000,
+    "end": 92300000,
+    "name": "10.q23.32",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 482,
+    "chromosome": "chr10",
+    "start": 92300000,
+    "end": 95300000,
+    "name": "10.q23.33",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 483,
+    "chromosome": "chr10",
+    "start": 95300000,
+    "end": 97500000,
+    "name": "10.q24.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 484,
+    "chromosome": "chr10",
+    "start": 97500000,
+    "end": 100100000,
+    "name": "10.q24.2",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 485,
+    "chromosome": "chr10",
+    "start": 100100000,
+    "end": 101200000,
+    "name": "10.q24.31",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 486,
+    "chromosome": "chr10",
+    "start": 101200000,
+    "end": 103100000,
+    "name": "10.q24.32",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 487,
+    "chromosome": "chr10",
+    "start": 103100000,
+    "end": 104000000,
+    "name": "10.q24.33",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 488,
+    "chromosome": "chr10",
+    "start": 104000000,
+    "end": 110100000,
+    "name": "10.q25.1",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 489,
+    "chromosome": "chr10",
+    "start": 110100000,
+    "end": 113100000,
+    "name": "10.q25.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 490,
+    "chromosome": "chr10",
+    "start": 113100000,
+    "end": 117300000,
+    "name": "10.q25.3",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 491,
+    "chromosome": "chr10",
+    "start": 117300000,
+    "end": 119900000,
+    "name": "10.q26.11",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 492,
+    "chromosome": "chr10",
+    "start": 119900000,
+    "end": 121400000,
+    "name": "10.q26.12",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 493,
+    "chromosome": "chr10",
+    "start": 121400000,
+    "end": 125700000,
+    "name": "10.q26.13",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 494,
+    "chromosome": "chr10",
+    "start": 125700000,
+    "end": 128800000,
+    "name": "10.q26.2",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 495,
+    "chromosome": "chr10",
+    "start": 128800000,
+    "end": 133797422,
+    "name": "10.q26.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 496,
+    "chromosome": "chr11",
+    "start": 0,
+    "end": 2800000,
+    "name": "11.p15.5",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 497,
+    "chromosome": "chr11",
+    "start": 2800000,
+    "end": 11700000,
+    "name": "11.p15.4",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 498,
+    "chromosome": "chr11",
+    "start": 11700000,
+    "end": 13800000,
+    "name": "11.p15.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 499,
+    "chromosome": "chr11",
+    "start": 13800000,
+    "end": 16900000,
+    "name": "11.p15.2",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 500,
+    "chromosome": "chr11",
+    "start": 16900000,
+    "end": 22000000,
+    "name": "11.p15.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 501,
+    "chromosome": "chr11",
+    "start": 22000000,
+    "end": 26200000,
+    "name": "11.p14.3",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 502,
+    "chromosome": "chr11",
+    "start": 26200000,
+    "end": 27200000,
+    "name": "11.p14.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 503,
+    "chromosome": "chr11",
+    "start": 27200000,
+    "end": 31000000,
+    "name": "11.p14.1",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 504,
+    "chromosome": "chr11",
+    "start": 31000000,
+    "end": 36400000,
+    "name": "11.p13",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 505,
+    "chromosome": "chr11",
+    "start": 36400000,
+    "end": 43400000,
+    "name": "11.p12",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 506,
+    "chromosome": "chr11",
+    "start": 43400000,
+    "end": 48800000,
+    "name": "11.p11.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 507,
+    "chromosome": "chr11",
+    "start": 48800000,
+    "end": 51000000,
+    "name": "11.p11.12",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 508,
+    "chromosome": "chr11",
+    "start": 51000000,
+    "end": 53400000,
+    "name": "11.p11.11",
+    "giemsaStains": "acen"
+  },
+  {
+    "id": 509,
+    "chromosome": "chr11",
+    "start": 53400000,
+    "end": 55800000,
+    "name": "11.q11",
+    "giemsaStains": "acen"
+  },
+  {
+    "id": 510,
+    "chromosome": "chr11",
+    "start": 55800000,
+    "end": 60100000,
+    "name": "11.q12.1",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 511,
+    "chromosome": "chr11",
+    "start": 60100000,
+    "end": 61900000,
+    "name": "11.q12.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 512,
+    "chromosome": "chr11",
+    "start": 61900000,
+    "end": 63600000,
+    "name": "11.q12.3",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 513,
+    "chromosome": "chr11",
+    "start": 63600000,
+    "end": 66100000,
+    "name": "11.q13.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 514,
+    "chromosome": "chr11",
+    "start": 66100000,
+    "end": 68700000,
+    "name": "11.q13.2",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 515,
+    "chromosome": "chr11",
+    "start": 68700000,
+    "end": 70500000,
+    "name": "11.q13.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 516,
+    "chromosome": "chr11",
+    "start": 70500000,
+    "end": 75500000,
+    "name": "11.q13.4",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 517,
+    "chromosome": "chr11",
+    "start": 75500000,
+    "end": 77400000,
+    "name": "11.q13.5",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 518,
+    "chromosome": "chr11",
+    "start": 77400000,
+    "end": 85900000,
+    "name": "11.q14.1",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 519,
+    "chromosome": "chr11",
+    "start": 85900000,
+    "end": 88600000,
+    "name": "11.q14.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 520,
+    "chromosome": "chr11",
+    "start": 88600000,
+    "end": 93000000,
+    "name": "11.q14.3",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 521,
+    "chromosome": "chr11",
+    "start": 93000000,
+    "end": 97400000,
+    "name": "11.q21",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 522,
+    "chromosome": "chr11",
+    "start": 97400000,
+    "end": 102300000,
+    "name": "11.q22.1",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 523,
+    "chromosome": "chr11",
+    "start": 102300000,
+    "end": 103000000,
+    "name": "11.q22.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 524,
+    "chromosome": "chr11",
+    "start": 103000000,
+    "end": 110600000,
+    "name": "11.q22.3",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 525,
+    "chromosome": "chr11",
+    "start": 110600000,
+    "end": 112700000,
+    "name": "11.q23.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 526,
+    "chromosome": "chr11",
+    "start": 112700000,
+    "end": 114600000,
+    "name": "11.q23.2",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 527,
+    "chromosome": "chr11",
+    "start": 114600000,
+    "end": 121300000,
+    "name": "11.q23.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 528,
+    "chromosome": "chr11",
+    "start": 121300000,
+    "end": 124000000,
+    "name": "11.q24.1",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 529,
+    "chromosome": "chr11",
+    "start": 124000000,
+    "end": 127900000,
+    "name": "11.q24.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 530,
+    "chromosome": "chr11",
+    "start": 127900000,
+    "end": 130900000,
+    "name": "11.q24.3",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 531,
+    "chromosome": "chr11",
+    "start": 130900000,
+    "end": 135086622,
+    "name": "11.q25",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 532,
+    "chromosome": "chr12",
+    "start": 0,
+    "end": 3200000,
+    "name": "12.p13.33",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 533,
+    "chromosome": "chr12",
+    "start": 3200000,
+    "end": 5300000,
+    "name": "12.p13.32",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 534,
+    "chromosome": "chr12",
+    "start": 5300000,
+    "end": 10000000,
+    "name": "12.p13.31",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 535,
+    "chromosome": "chr12",
+    "start": 10000000,
+    "end": 12600000,
+    "name": "12.p13.2",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 536,
+    "chromosome": "chr12",
+    "start": 12600000,
+    "end": 14600000,
+    "name": "12.p13.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 537,
+    "chromosome": "chr12",
+    "start": 14600000,
+    "end": 19800000,
+    "name": "12.p12.3",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 538,
+    "chromosome": "chr12",
+    "start": 19800000,
+    "end": 21100000,
+    "name": "12.p12.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 539,
+    "chromosome": "chr12",
+    "start": 21100000,
+    "end": 26300000,
+    "name": "12.p12.1",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 540,
+    "chromosome": "chr12",
+    "start": 26300000,
+    "end": 27600000,
+    "name": "12.p11.23",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 541,
+    "chromosome": "chr12",
+    "start": 27600000,
+    "end": 30500000,
+    "name": "12.p11.22",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 542,
+    "chromosome": "chr12",
+    "start": 30500000,
+    "end": 33200000,
+    "name": "12.p11.21",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 543,
+    "chromosome": "chr12",
+    "start": 33200000,
+    "end": 35500000,
+    "name": "12.p11.1",
+    "giemsaStains": "acen"
+  },
+  {
+    "id": 544,
+    "chromosome": "chr12",
+    "start": 35500000,
+    "end": 37800000,
+    "name": "12.q11",
+    "giemsaStains": "acen"
+  },
+  {
+    "id": 545,
+    "chromosome": "chr12",
+    "start": 37800000,
+    "end": 46000000,
+    "name": "12.q12",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 546,
+    "chromosome": "chr12",
+    "start": 46000000,
+    "end": 48700000,
+    "name": "12.q13.11",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 547,
+    "chromosome": "chr12",
+    "start": 48700000,
+    "end": 51100000,
+    "name": "12.q13.12",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 548,
+    "chromosome": "chr12",
+    "start": 51100000,
+    "end": 54500000,
+    "name": "12.q13.13",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 549,
+    "chromosome": "chr12",
+    "start": 54500000,
+    "end": 56200000,
+    "name": "12.q13.2",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 550,
+    "chromosome": "chr12",
+    "start": 56200000,
+    "end": 57700000,
+    "name": "12.q13.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 551,
+    "chromosome": "chr12",
+    "start": 57700000,
+    "end": 62700000,
+    "name": "12.q14.1",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 552,
+    "chromosome": "chr12",
+    "start": 62700000,
+    "end": 64700000,
+    "name": "12.q14.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 553,
+    "chromosome": "chr12",
+    "start": 64700000,
+    "end": 67300000,
+    "name": "12.q14.3",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 554,
+    "chromosome": "chr12",
+    "start": 67300000,
+    "end": 71100000,
+    "name": "12.q15",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 555,
+    "chromosome": "chr12",
+    "start": 71100000,
+    "end": 75300000,
+    "name": "12.q21.1",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 556,
+    "chromosome": "chr12",
+    "start": 75300000,
+    "end": 79900000,
+    "name": "12.q21.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 557,
+    "chromosome": "chr12",
+    "start": 79900000,
+    "end": 86300000,
+    "name": "12.q21.31",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 558,
+    "chromosome": "chr12",
+    "start": 86300000,
+    "end": 88600000,
+    "name": "12.q21.32",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 559,
+    "chromosome": "chr12",
+    "start": 88600000,
+    "end": 92200000,
+    "name": "12.q21.33",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 560,
+    "chromosome": "chr12",
+    "start": 92200000,
+    "end": 95800000,
+    "name": "12.q22",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 561,
+    "chromosome": "chr12",
+    "start": 95800000,
+    "end": 101200000,
+    "name": "12.q23.1",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 562,
+    "chromosome": "chr12",
+    "start": 101200000,
+    "end": 103500000,
+    "name": "12.q23.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 563,
+    "chromosome": "chr12",
+    "start": 103500000,
+    "end": 108600000,
+    "name": "12.q23.3",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 564,
+    "chromosome": "chr12",
+    "start": 108600000,
+    "end": 111300000,
+    "name": "12.q24.11",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 565,
+    "chromosome": "chr12",
+    "start": 111300000,
+    "end": 111900000,
+    "name": "12.q24.12",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 566,
+    "chromosome": "chr12",
+    "start": 111900000,
+    "end": 113900000,
+    "name": "12.q24.13",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 567,
+    "chromosome": "chr12",
+    "start": 113900000,
+    "end": 116400000,
+    "name": "12.q24.21",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 568,
+    "chromosome": "chr12",
+    "start": 116400000,
+    "end": 117700000,
+    "name": "12.q24.22",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 569,
+    "chromosome": "chr12",
+    "start": 117700000,
+    "end": 120300000,
+    "name": "12.q24.23",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 570,
+    "chromosome": "chr12",
+    "start": 120300000,
+    "end": 125400000,
+    "name": "12.q24.31",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 571,
+    "chromosome": "chr12",
+    "start": 125400000,
+    "end": 128700000,
+    "name": "12.q24.32",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 572,
+    "chromosome": "chr12",
+    "start": 128700000,
+    "end": 133275309,
+    "name": "12.q24.33",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 573,
+    "chromosome": "chr13",
+    "start": 0,
+    "end": 4600000,
+    "name": "13.p13",
+    "giemsaStains": "gvar"
+  },
+  {
+    "id": 574,
+    "chromosome": "chr13",
+    "start": 4600000,
+    "end": 10100000,
+    "name": "13.p12",
+    "giemsaStains": "stalk"
+  },
+  {
+    "id": 575,
+    "chromosome": "chr13",
+    "start": 10100000,
+    "end": 16500000,
+    "name": "13.p11.2",
+    "giemsaStains": "gvar"
+  },
+  {
+    "id": 576,
+    "chromosome": "chr13",
+    "start": 16500000,
+    "end": 17700000,
+    "name": "13.p11.1",
+    "giemsaStains": "acen"
+  },
+  {
+    "id": 577,
+    "chromosome": "chr13",
+    "start": 17700000,
+    "end": 18900000,
+    "name": "13.q11",
+    "giemsaStains": "acen"
+  },
+  {
+    "id": 578,
+    "chromosome": "chr13",
+    "start": 18900000,
+    "end": 22600000,
+    "name": "13.q12.11",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 579,
+    "chromosome": "chr13",
+    "start": 22600000,
+    "end": 24900000,
+    "name": "13.q12.12",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 580,
+    "chromosome": "chr13",
+    "start": 24900000,
+    "end": 27200000,
+    "name": "13.q12.13",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 581,
+    "chromosome": "chr13",
+    "start": 27200000,
+    "end": 28300000,
+    "name": "13.q12.2",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 582,
+    "chromosome": "chr13",
+    "start": 28300000,
+    "end": 31600000,
+    "name": "13.q12.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 583,
+    "chromosome": "chr13",
+    "start": 31600000,
+    "end": 33400000,
+    "name": "13.q13.1",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 584,
+    "chromosome": "chr13",
+    "start": 33400000,
+    "end": 34900000,
+    "name": "13.q13.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 585,
+    "chromosome": "chr13",
+    "start": 34900000,
+    "end": 39500000,
+    "name": "13.q13.3",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 586,
+    "chromosome": "chr13",
+    "start": 39500000,
+    "end": 44600000,
+    "name": "13.q14.11",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 587,
+    "chromosome": "chr13",
+    "start": 44600000,
+    "end": 45200000,
+    "name": "13.q14.12",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 588,
+    "chromosome": "chr13",
+    "start": 45200000,
+    "end": 46700000,
+    "name": "13.q14.13",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 589,
+    "chromosome": "chr13",
+    "start": 46700000,
+    "end": 50300000,
+    "name": "13.q14.2",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 590,
+    "chromosome": "chr13",
+    "start": 50300000,
+    "end": 54700000,
+    "name": "13.q14.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 591,
+    "chromosome": "chr13",
+    "start": 54700000,
+    "end": 59000000,
+    "name": "13.q21.1",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 592,
+    "chromosome": "chr13",
+    "start": 59000000,
+    "end": 61800000,
+    "name": "13.q21.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 593,
+    "chromosome": "chr13",
+    "start": 61800000,
+    "end": 65200000,
+    "name": "13.q21.31",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 594,
+    "chromosome": "chr13",
+    "start": 65200000,
+    "end": 68100000,
+    "name": "13.q21.32",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 595,
+    "chromosome": "chr13",
+    "start": 68100000,
+    "end": 72800000,
+    "name": "13.q21.33",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 596,
+    "chromosome": "chr13",
+    "start": 72800000,
+    "end": 74900000,
+    "name": "13.q22.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 597,
+    "chromosome": "chr13",
+    "start": 74900000,
+    "end": 76700000,
+    "name": "13.q22.2",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 598,
+    "chromosome": "chr13",
+    "start": 76700000,
+    "end": 78500000,
+    "name": "13.q22.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 599,
+    "chromosome": "chr13",
+    "start": 78500000,
+    "end": 87100000,
+    "name": "13.q31.1",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 600,
+    "chromosome": "chr13",
+    "start": 87100000,
+    "end": 89400000,
+    "name": "13.q31.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 601,
+    "chromosome": "chr13",
+    "start": 89400000,
+    "end": 94400000,
+    "name": "13.q31.3",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 602,
+    "chromosome": "chr13",
+    "start": 94400000,
+    "end": 97500000,
+    "name": "13.q32.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 603,
+    "chromosome": "chr13",
+    "start": 97500000,
+    "end": 98700000,
+    "name": "13.q32.2",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 604,
+    "chromosome": "chr13",
+    "start": 98700000,
+    "end": 101100000,
+    "name": "13.q32.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 605,
+    "chromosome": "chr13",
+    "start": 101100000,
+    "end": 104200000,
+    "name": "13.q33.1",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 606,
+    "chromosome": "chr13",
+    "start": 104200000,
+    "end": 106400000,
+    "name": "13.q33.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 607,
+    "chromosome": "chr13",
+    "start": 106400000,
+    "end": 109600000,
+    "name": "13.q33.3",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 608,
+    "chromosome": "chr13",
+    "start": 109600000,
+    "end": 114364328,
+    "name": "13.q34",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 609,
+    "chromosome": "chr14",
+    "start": 0,
+    "end": 3600000,
+    "name": "14.p13",
+    "giemsaStains": "gvar"
+  },
+  {
+    "id": 610,
+    "chromosome": "chr14",
+    "start": 3600000,
+    "end": 8000000,
+    "name": "14.p12",
+    "giemsaStains": "stalk"
+  },
+  {
+    "id": 611,
+    "chromosome": "chr14",
+    "start": 8000000,
+    "end": 16100000,
+    "name": "14.p11.2",
+    "giemsaStains": "gvar"
+  },
+  {
+    "id": 612,
+    "chromosome": "chr14",
+    "start": 16100000,
+    "end": 17200000,
+    "name": "14.p11.1",
+    "giemsaStains": "acen"
+  },
+  {
+    "id": 613,
+    "chromosome": "chr14",
+    "start": 17200000,
+    "end": 18200000,
+    "name": "14.q11.1",
+    "giemsaStains": "acen"
+  },
+  {
+    "id": 614,
+    "chromosome": "chr14",
+    "start": 18200000,
+    "end": 24100000,
+    "name": "14.q11.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 615,
+    "chromosome": "chr14",
+    "start": 24100000,
+    "end": 32900000,
+    "name": "14.q12",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 616,
+    "chromosome": "chr14",
+    "start": 32900000,
+    "end": 34800000,
+    "name": "14.q13.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 617,
+    "chromosome": "chr14",
+    "start": 34800000,
+    "end": 36100000,
+    "name": "14.q13.2",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 618,
+    "chromosome": "chr14",
+    "start": 36100000,
+    "end": 37400000,
+    "name": "14.q13.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 619,
+    "chromosome": "chr14",
+    "start": 37400000,
+    "end": 43000000,
+    "name": "14.q21.1",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 620,
+    "chromosome": "chr14",
+    "start": 43000000,
+    "end": 46700000,
+    "name": "14.q21.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 621,
+    "chromosome": "chr14",
+    "start": 46700000,
+    "end": 50400000,
+    "name": "14.q21.3",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 622,
+    "chromosome": "chr14",
+    "start": 50400000,
+    "end": 53600000,
+    "name": "14.q22.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 623,
+    "chromosome": "chr14",
+    "start": 53600000,
+    "end": 55000000,
+    "name": "14.q22.2",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 624,
+    "chromosome": "chr14",
+    "start": 55000000,
+    "end": 57600000,
+    "name": "14.q22.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 625,
+    "chromosome": "chr14",
+    "start": 57600000,
+    "end": 61600000,
+    "name": "14.q23.1",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 626,
+    "chromosome": "chr14",
+    "start": 61600000,
+    "end": 64300000,
+    "name": "14.q23.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 627,
+    "chromosome": "chr14",
+    "start": 64300000,
+    "end": 67400000,
+    "name": "14.q23.3",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 628,
+    "chromosome": "chr14",
+    "start": 67400000,
+    "end": 69800000,
+    "name": "14.q24.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 629,
+    "chromosome": "chr14",
+    "start": 69800000,
+    "end": 73300000,
+    "name": "14.q24.2",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 630,
+    "chromosome": "chr14",
+    "start": 73300000,
+    "end": 78800000,
+    "name": "14.q24.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 631,
+    "chromosome": "chr14",
+    "start": 78800000,
+    "end": 83100000,
+    "name": "14.q31.1",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 632,
+    "chromosome": "chr14",
+    "start": 83100000,
+    "end": 84400000,
+    "name": "14.q31.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 633,
+    "chromosome": "chr14",
+    "start": 84400000,
+    "end": 89300000,
+    "name": "14.q31.3",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 634,
+    "chromosome": "chr14",
+    "start": 89300000,
+    "end": 91400000,
+    "name": "14.q32.11",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 635,
+    "chromosome": "chr14",
+    "start": 91400000,
+    "end": 94200000,
+    "name": "14.q32.12",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 636,
+    "chromosome": "chr14",
+    "start": 94200000,
+    "end": 95800000,
+    "name": "14.q32.13",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 637,
+    "chromosome": "chr14",
+    "start": 95800000,
+    "end": 100900000,
+    "name": "14.q32.2",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 638,
+    "chromosome": "chr14",
+    "start": 100900000,
+    "end": 102700000,
+    "name": "14.q32.31",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 639,
+    "chromosome": "chr14",
+    "start": 102700000,
+    "end": 103500000,
+    "name": "14.q32.32",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 640,
+    "chromosome": "chr14",
+    "start": 103500000,
+    "end": 107043718,
+    "name": "14.q32.33",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 641,
+    "chromosome": "chr15",
+    "start": 0,
+    "end": 4200000,
+    "name": "15.p13",
+    "giemsaStains": "gvar"
+  },
+  {
+    "id": 642,
+    "chromosome": "chr15",
+    "start": 4200000,
+    "end": 9700000,
+    "name": "15.p12",
+    "giemsaStains": "stalk"
+  },
+  {
+    "id": 643,
+    "chromosome": "chr15",
+    "start": 9700000,
+    "end": 17500000,
+    "name": "15.p11.2",
+    "giemsaStains": "gvar"
+  },
+  {
+    "id": 644,
+    "chromosome": "chr15",
+    "start": 17500000,
+    "end": 19000000,
+    "name": "15.p11.1",
+    "giemsaStains": "acen"
+  },
+  {
+    "id": 645,
+    "chromosome": "chr15",
+    "start": 19000000,
+    "end": 20500000,
+    "name": "15.q11.1",
+    "giemsaStains": "acen"
+  },
+  {
+    "id": 646,
+    "chromosome": "chr15",
+    "start": 20500000,
+    "end": 25500000,
+    "name": "15.q11.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 647,
+    "chromosome": "chr15",
+    "start": 25500000,
+    "end": 27800000,
+    "name": "15.q12",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 648,
+    "chromosome": "chr15",
+    "start": 27800000,
+    "end": 30000000,
+    "name": "15.q13.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 649,
+    "chromosome": "chr15",
+    "start": 30000000,
+    "end": 30900000,
+    "name": "15.q13.2",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 650,
+    "chromosome": "chr15",
+    "start": 30900000,
+    "end": 33400000,
+    "name": "15.q13.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 651,
+    "chromosome": "chr15",
+    "start": 33400000,
+    "end": 39800000,
+    "name": "15.q14",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 652,
+    "chromosome": "chr15",
+    "start": 39800000,
+    "end": 42500000,
+    "name": "15.q15.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 653,
+    "chromosome": "chr15",
+    "start": 42500000,
+    "end": 43300000,
+    "name": "15.q15.2",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 654,
+    "chromosome": "chr15",
+    "start": 43300000,
+    "end": 44500000,
+    "name": "15.q15.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 655,
+    "chromosome": "chr15",
+    "start": 44500000,
+    "end": 49200000,
+    "name": "15.q21.1",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 656,
+    "chromosome": "chr15",
+    "start": 49200000,
+    "end": 52600000,
+    "name": "15.q21.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 657,
+    "chromosome": "chr15",
+    "start": 52600000,
+    "end": 58800000,
+    "name": "15.q21.3",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 658,
+    "chromosome": "chr15",
+    "start": 58800000,
+    "end": 59000000,
+    "name": "15.q22.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 659,
+    "chromosome": "chr15",
+    "start": 59000000,
+    "end": 63400000,
+    "name": "15.q22.2",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 660,
+    "chromosome": "chr15",
+    "start": 63400000,
+    "end": 66900000,
+    "name": "15.q22.31",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 661,
+    "chromosome": "chr15",
+    "start": 66900000,
+    "end": 67000000,
+    "name": "15.q22.32",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 662,
+    "chromosome": "chr15",
+    "start": 67000000,
+    "end": 67200000,
+    "name": "15.q22.33",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 663,
+    "chromosome": "chr15",
+    "start": 67200000,
+    "end": 72400000,
+    "name": "15.q23",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 664,
+    "chromosome": "chr15",
+    "start": 72400000,
+    "end": 74900000,
+    "name": "15.q24.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 665,
+    "chromosome": "chr15",
+    "start": 74900000,
+    "end": 76300000,
+    "name": "15.q24.2",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 666,
+    "chromosome": "chr15",
+    "start": 76300000,
+    "end": 78000000,
+    "name": "15.q24.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 667,
+    "chromosome": "chr15",
+    "start": 78000000,
+    "end": 81400000,
+    "name": "15.q25.1",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 668,
+    "chromosome": "chr15",
+    "start": 81400000,
+    "end": 84700000,
+    "name": "15.q25.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 669,
+    "chromosome": "chr15",
+    "start": 84700000,
+    "end": 88500000,
+    "name": "15.q25.3",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 670,
+    "chromosome": "chr15",
+    "start": 88500000,
+    "end": 93800000,
+    "name": "15.q26.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 671,
+    "chromosome": "chr15",
+    "start": 93800000,
+    "end": 98000000,
+    "name": "15.q26.2",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 672,
+    "chromosome": "chr15",
+    "start": 98000000,
+    "end": 101991189,
+    "name": "15.q26.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 673,
+    "chromosome": "chr16",
+    "start": 0,
+    "end": 7800000,
+    "name": "16.p13.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 674,
+    "chromosome": "chr16",
+    "start": 7800000,
+    "end": 10400000,
+    "name": "16.p13.2",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 675,
+    "chromosome": "chr16",
+    "start": 10400000,
+    "end": 12500000,
+    "name": "16.p13.13",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 676,
+    "chromosome": "chr16",
+    "start": 12500000,
+    "end": 14700000,
+    "name": "16.p13.12",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 677,
+    "chromosome": "chr16",
+    "start": 14700000,
+    "end": 16700000,
+    "name": "16.p13.11",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 678,
+    "chromosome": "chr16",
+    "start": 16700000,
+    "end": 21200000,
+    "name": "16.p12.3",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 679,
+    "chromosome": "chr16",
+    "start": 21200000,
+    "end": 24200000,
+    "name": "16.p12.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 680,
+    "chromosome": "chr16",
+    "start": 24200000,
+    "end": 28500000,
+    "name": "16.p12.1",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 681,
+    "chromosome": "chr16",
+    "start": 28500000,
+    "end": 35300000,
+    "name": "16.p11.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 682,
+    "chromosome": "chr16",
+    "start": 35300000,
+    "end": 36800000,
+    "name": "16.p11.1",
+    "giemsaStains": "acen"
+  },
+  {
+    "id": 683,
+    "chromosome": "chr16",
+    "start": 36800000,
+    "end": 38400000,
+    "name": "16.q11.1",
+    "giemsaStains": "acen"
+  },
+  {
+    "id": 684,
+    "chromosome": "chr16",
+    "start": 38400000,
+    "end": 47000000,
+    "name": "16.q11.2",
+    "giemsaStains": "gvar"
+  },
+  {
+    "id": 685,
+    "chromosome": "chr16",
+    "start": 47000000,
+    "end": 52600000,
+    "name": "16.q12.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 686,
+    "chromosome": "chr16",
+    "start": 52600000,
+    "end": 56000000,
+    "name": "16.q12.2",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 687,
+    "chromosome": "chr16",
+    "start": 56000000,
+    "end": 57300000,
+    "name": "16.q13",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 688,
+    "chromosome": "chr16",
+    "start": 57300000,
+    "end": 66600000,
+    "name": "16.q21",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 689,
+    "chromosome": "chr16",
+    "start": 66600000,
+    "end": 70800000,
+    "name": "16.q22.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 690,
+    "chromosome": "chr16",
+    "start": 70800000,
+    "end": 72800000,
+    "name": "16.q22.2",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 691,
+    "chromosome": "chr16",
+    "start": 72800000,
+    "end": 74100000,
+    "name": "16.q22.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 692,
+    "chromosome": "chr16",
+    "start": 74100000,
+    "end": 79200000,
+    "name": "16.q23.1",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 693,
+    "chromosome": "chr16",
+    "start": 79200000,
+    "end": 81600000,
+    "name": "16.q23.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 694,
+    "chromosome": "chr16",
+    "start": 81600000,
+    "end": 84100000,
+    "name": "16.q23.3",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 695,
+    "chromosome": "chr16",
+    "start": 84100000,
+    "end": 87000000,
+    "name": "16.q24.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 696,
+    "chromosome": "chr16",
+    "start": 87000000,
+    "end": 88700000,
+    "name": "16.q24.2",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 697,
+    "chromosome": "chr16",
+    "start": 88700000,
+    "end": 90338345,
+    "name": "16.q24.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 698,
+    "chromosome": "chr17",
+    "start": 0,
+    "end": 3400000,
+    "name": "17.p13.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 699,
+    "chromosome": "chr17",
+    "start": 3400000,
+    "end": 6500000,
+    "name": "17.p13.2",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 700,
+    "chromosome": "chr17",
+    "start": 6500000,
+    "end": 10800000,
+    "name": "17.p13.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 701,
+    "chromosome": "chr17",
+    "start": 10800000,
+    "end": 16100000,
+    "name": "17.p12",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 702,
+    "chromosome": "chr17",
+    "start": 16100000,
+    "end": 22700000,
+    "name": "17.p11.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 703,
+    "chromosome": "chr17",
+    "start": 22700000,
+    "end": 25100000,
+    "name": "17.p11.1",
+    "giemsaStains": "acen"
+  },
+  {
+    "id": 704,
+    "chromosome": "chr17",
+    "start": 25100000,
+    "end": 27400000,
+    "name": "17.q11.1",
+    "giemsaStains": "acen"
+  },
+  {
+    "id": 705,
+    "chromosome": "chr17",
+    "start": 27400000,
+    "end": 33500000,
+    "name": "17.q11.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 706,
+    "chromosome": "chr17",
+    "start": 33500000,
+    "end": 39800000,
+    "name": "17.q12",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 707,
+    "chromosome": "chr17",
+    "start": 39800000,
+    "end": 40200000,
+    "name": "17.q21.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 708,
+    "chromosome": "chr17",
+    "start": 40200000,
+    "end": 42800000,
+    "name": "17.q21.2",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 709,
+    "chromosome": "chr17",
+    "start": 42800000,
+    "end": 46800000,
+    "name": "17.q21.31",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 710,
+    "chromosome": "chr17",
+    "start": 46800000,
+    "end": 49300000,
+    "name": "17.q21.32",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 711,
+    "chromosome": "chr17",
+    "start": 49300000,
+    "end": 52100000,
+    "name": "17.q21.33",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 712,
+    "chromosome": "chr17",
+    "start": 52100000,
+    "end": 59500000,
+    "name": "17.q22",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 713,
+    "chromosome": "chr17",
+    "start": 59500000,
+    "end": 60200000,
+    "name": "17.q23.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 714,
+    "chromosome": "chr17",
+    "start": 60200000,
+    "end": 63100000,
+    "name": "17.q23.2",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 715,
+    "chromosome": "chr17",
+    "start": 63100000,
+    "end": 64600000,
+    "name": "17.q23.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 716,
+    "chromosome": "chr17",
+    "start": 64600000,
+    "end": 66200000,
+    "name": "17.q24.1",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 717,
+    "chromosome": "chr17",
+    "start": 66200000,
+    "end": 69100000,
+    "name": "17.q24.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 718,
+    "chromosome": "chr17",
+    "start": 69100000,
+    "end": 72900000,
+    "name": "17.q24.3",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 719,
+    "chromosome": "chr17",
+    "start": 72900000,
+    "end": 76800000,
+    "name": "17.q25.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 720,
+    "chromosome": "chr17",
+    "start": 76800000,
+    "end": 77200000,
+    "name": "17.q25.2",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 721,
+    "chromosome": "chr17",
+    "start": 77200000,
+    "end": 83257441,
+    "name": "17.q25.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 722,
+    "chromosome": "chr18",
+    "start": 0,
+    "end": 2900000,
+    "name": "18.p11.32",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 723,
+    "chromosome": "chr18",
+    "start": 2900000,
+    "end": 7200000,
+    "name": "18.p11.31",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 724,
+    "chromosome": "chr18",
+    "start": 7200000,
+    "end": 8500000,
+    "name": "18.p11.23",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 725,
+    "chromosome": "chr18",
+    "start": 8500000,
+    "end": 10900000,
+    "name": "18.p11.22",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 726,
+    "chromosome": "chr18",
+    "start": 10900000,
+    "end": 15400000,
+    "name": "18.p11.21",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 727,
+    "chromosome": "chr18",
+    "start": 15400000,
+    "end": 18500000,
+    "name": "18.p11.1",
+    "giemsaStains": "acen"
+  },
+  {
+    "id": 728,
+    "chromosome": "chr18",
+    "start": 18500000,
+    "end": 21500000,
+    "name": "18.q11.1",
+    "giemsaStains": "acen"
+  },
+  {
+    "id": 729,
+    "chromosome": "chr18",
+    "start": 21500000,
+    "end": 27500000,
+    "name": "18.q11.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 730,
+    "chromosome": "chr18",
+    "start": 27500000,
+    "end": 35100000,
+    "name": "18.q12.1",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 731,
+    "chromosome": "chr18",
+    "start": 35100000,
+    "end": 39500000,
+    "name": "18.q12.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 732,
+    "chromosome": "chr18",
+    "start": 39500000,
+    "end": 45900000,
+    "name": "18.q12.3",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 733,
+    "chromosome": "chr18",
+    "start": 45900000,
+    "end": 50700000,
+    "name": "18.q21.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 734,
+    "chromosome": "chr18",
+    "start": 50700000,
+    "end": 56200000,
+    "name": "18.q21.2",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 735,
+    "chromosome": "chr18",
+    "start": 56200000,
+    "end": 58600000,
+    "name": "18.q21.31",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 736,
+    "chromosome": "chr18",
+    "start": 58600000,
+    "end": 61300000,
+    "name": "18.q21.32",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 737,
+    "chromosome": "chr18",
+    "start": 61300000,
+    "end": 63900000,
+    "name": "18.q21.33",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 738,
+    "chromosome": "chr18",
+    "start": 63900000,
+    "end": 69100000,
+    "name": "18.q22.1",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 739,
+    "chromosome": "chr18",
+    "start": 69100000,
+    "end": 71000000,
+    "name": "18.q22.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 740,
+    "chromosome": "chr18",
+    "start": 71000000,
+    "end": 75400000,
+    "name": "18.q22.3",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 741,
+    "chromosome": "chr18",
+    "start": 75400000,
+    "end": 80373285,
+    "name": "18.q23",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 742,
+    "chromosome": "chr19",
+    "start": 0,
+    "end": 6900000,
+    "name": "19.p13.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 743,
+    "chromosome": "chr19",
+    "start": 6900000,
+    "end": 12600000,
+    "name": "19.p13.2",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 744,
+    "chromosome": "chr19",
+    "start": 12600000,
+    "end": 13800000,
+    "name": "19.p13.13",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 745,
+    "chromosome": "chr19",
+    "start": 13800000,
+    "end": 16100000,
+    "name": "19.p13.12",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 746,
+    "chromosome": "chr19",
+    "start": 16100000,
+    "end": 19900000,
+    "name": "19.p13.11",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 747,
+    "chromosome": "chr19",
+    "start": 19900000,
+    "end": 24200000,
+    "name": "19.p12",
+    "giemsaStains": "gvar"
+  },
+  {
+    "id": 748,
+    "chromosome": "chr19",
+    "start": 24200000,
+    "end": 26200000,
+    "name": "19.p11",
+    "giemsaStains": "acen"
+  },
+  {
+    "id": 749,
+    "chromosome": "chr19",
+    "start": 26200000,
+    "end": 28100000,
+    "name": "19.q11",
+    "giemsaStains": "acen"
+  },
+  {
+    "id": 750,
+    "chromosome": "chr19",
+    "start": 28100000,
+    "end": 31900000,
+    "name": "19.q12",
+    "giemsaStains": "gvar"
+  },
+  {
+    "id": 751,
+    "chromosome": "chr19",
+    "start": 31900000,
+    "end": 35100000,
+    "name": "19.q13.11",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 752,
+    "chromosome": "chr19",
+    "start": 35100000,
+    "end": 37800000,
+    "name": "19.q13.12",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 753,
+    "chromosome": "chr19",
+    "start": 37800000,
+    "end": 38200000,
+    "name": "19.q13.13",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 754,
+    "chromosome": "chr19",
+    "start": 38200000,
+    "end": 42900000,
+    "name": "19.q13.2",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 755,
+    "chromosome": "chr19",
+    "start": 42900000,
+    "end": 44700000,
+    "name": "19.q13.31",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 756,
+    "chromosome": "chr19",
+    "start": 44700000,
+    "end": 47500000,
+    "name": "19.q13.32",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 757,
+    "chromosome": "chr19",
+    "start": 47500000,
+    "end": 50900000,
+    "name": "19.q13.33",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 758,
+    "chromosome": "chr19",
+    "start": 50900000,
+    "end": 53100000,
+    "name": "19.q13.41",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 759,
+    "chromosome": "chr19",
+    "start": 53100000,
+    "end": 55800000,
+    "name": "19.q13.42",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 760,
+    "chromosome": "chr19",
+    "start": 55800000,
+    "end": 58617616,
+    "name": "19.q13.43",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 761,
+    "chromosome": "chr20",
+    "start": 0,
+    "end": 5100000,
+    "name": "20.p13",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 762,
+    "chromosome": "chr20",
+    "start": 5100000,
+    "end": 9200000,
+    "name": "20.p12.3",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 763,
+    "chromosome": "chr20",
+    "start": 9200000,
+    "end": 12000000,
+    "name": "20.p12.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 764,
+    "chromosome": "chr20",
+    "start": 12000000,
+    "end": 17900000,
+    "name": "20.p12.1",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 765,
+    "chromosome": "chr20",
+    "start": 17900000,
+    "end": 21300000,
+    "name": "20.p11.23",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 766,
+    "chromosome": "chr20",
+    "start": 21300000,
+    "end": 22300000,
+    "name": "20.p11.22",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 767,
+    "chromosome": "chr20",
+    "start": 22300000,
+    "end": 25700000,
+    "name": "20.p11.21",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 768,
+    "chromosome": "chr20",
+    "start": 25700000,
+    "end": 28100000,
+    "name": "20.p11.1",
+    "giemsaStains": "acen"
+  },
+  {
+    "id": 769,
+    "chromosome": "chr20",
+    "start": 28100000,
+    "end": 30400000,
+    "name": "20.q11.1",
+    "giemsaStains": "acen"
+  },
+  {
+    "id": 770,
+    "chromosome": "chr20",
+    "start": 30400000,
+    "end": 33500000,
+    "name": "20.q11.21",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 771,
+    "chromosome": "chr20",
+    "start": 33500000,
+    "end": 35800000,
+    "name": "20.q11.22",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 772,
+    "chromosome": "chr20",
+    "start": 35800000,
+    "end": 39000000,
+    "name": "20.q11.23",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 773,
+    "chromosome": "chr20",
+    "start": 39000000,
+    "end": 43100000,
+    "name": "20.q12",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 774,
+    "chromosome": "chr20",
+    "start": 43100000,
+    "end": 43500000,
+    "name": "20.q13.11",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 775,
+    "chromosome": "chr20",
+    "start": 43500000,
+    "end": 47800000,
+    "name": "20.q13.12",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 776,
+    "chromosome": "chr20",
+    "start": 47800000,
+    "end": 51200000,
+    "name": "20.q13.13",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 777,
+    "chromosome": "chr20",
+    "start": 51200000,
+    "end": 56400000,
+    "name": "20.q13.2",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 778,
+    "chromosome": "chr20",
+    "start": 56400000,
+    "end": 57800000,
+    "name": "20.q13.31",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 779,
+    "chromosome": "chr20",
+    "start": 57800000,
+    "end": 59700000,
+    "name": "20.q13.32",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 780,
+    "chromosome": "chr20",
+    "start": 59700000,
+    "end": 64444167,
+    "name": "20.q13.33",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 781,
+    "chromosome": "chr21",
+    "start": 0,
+    "end": 3100000,
+    "name": "21.p13",
+    "giemsaStains": "gvar"
+  },
+  {
+    "id": 782,
+    "chromosome": "chr21",
+    "start": 3100000,
+    "end": 7000000,
+    "name": "21.p12",
+    "giemsaStains": "stalk"
+  },
+  {
+    "id": 783,
+    "chromosome": "chr21",
+    "start": 7000000,
+    "end": 10900000,
+    "name": "21.p11.2",
+    "giemsaStains": "gvar"
+  },
+  {
+    "id": 784,
+    "chromosome": "chr21",
+    "start": 10900000,
+    "end": 12000000,
+    "name": "21.p11.1",
+    "giemsaStains": "acen"
+  },
+  {
+    "id": 785,
+    "chromosome": "chr21",
+    "start": 12000000,
+    "end": 13000000,
+    "name": "21.q11.1",
+    "giemsaStains": "acen"
+  },
+  {
+    "id": 786,
+    "chromosome": "chr21",
+    "start": 13000000,
+    "end": 15000000,
+    "name": "21.q11.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 787,
+    "chromosome": "chr21",
+    "start": 15000000,
+    "end": 22600000,
+    "name": "21.q21.1",
+    "giemsaStains": "gpos100"
+  },
+  {
+    "id": 788,
+    "chromosome": "chr21",
+    "start": 22600000,
+    "end": 25500000,
+    "name": "21.q21.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 789,
+    "chromosome": "chr21",
+    "start": 25500000,
+    "end": 30200000,
+    "name": "21.q21.3",
+    "giemsaStains": "gpos75"
+  },
+  {
+    "id": 790,
+    "chromosome": "chr21",
+    "start": 30200000,
+    "end": 34400000,
+    "name": "21.q22.11",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 791,
+    "chromosome": "chr21",
+    "start": 34400000,
+    "end": 36400000,
+    "name": "21.q22.12",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 792,
+    "chromosome": "chr21",
+    "start": 36400000,
+    "end": 38300000,
+    "name": "21.q22.13",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 793,
+    "chromosome": "chr21",
+    "start": 38300000,
+    "end": 41200000,
+    "name": "21.q22.2",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 794,
+    "chromosome": "chr21",
+    "start": 41200000,
+    "end": 46709983,
+    "name": "21.q22.3",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 795,
+    "chromosome": "chr22",
+    "start": 0,
+    "end": 4300000,
+    "name": "22.p13",
+    "giemsaStains": "gvar"
+  },
+  {
+    "id": 796,
+    "chromosome": "chr22",
+    "start": 4300000,
+    "end": 9400000,
+    "name": "22.p12",
+    "giemsaStains": "stalk"
+  },
+  {
+    "id": 797,
+    "chromosome": "chr22",
+    "start": 9400000,
+    "end": 13700000,
+    "name": "22.p11.2",
+    "giemsaStains": "gvar"
+  },
+  {
+    "id": 798,
+    "chromosome": "chr22",
+    "start": 13700000,
+    "end": 15000000,
+    "name": "22.p11.1",
+    "giemsaStains": "acen"
+  },
+  {
+    "id": 799,
+    "chromosome": "chr22",
+    "start": 15000000,
+    "end": 17400000,
+    "name": "22.q11.1",
+    "giemsaStains": "acen"
+  },
+  {
+    "id": 800,
+    "chromosome": "chr22",
+    "start": 17400000,
+    "end": 21700000,
+    "name": "22.q11.21",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 801,
+    "chromosome": "chr22",
+    "start": 21700000,
+    "end": 23100000,
+    "name": "22.q11.22",
+    "giemsaStains": "gpos25"
+  },
+  {
+    "id": 802,
+    "chromosome": "chr22",
+    "start": 23100000,
+    "end": 25500000,
+    "name": "22.q11.23",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 803,
+    "chromosome": "chr22",
+    "start": 25500000,
+    "end": 29200000,
+    "name": "22.q12.1",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 804,
+    "chromosome": "chr22",
+    "start": 29200000,
+    "end": 31800000,
+    "name": "22.q12.2",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 805,
+    "chromosome": "chr22",
+    "start": 31800000,
+    "end": 37200000,
+    "name": "22.q12.3",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 806,
+    "chromosome": "chr22",
+    "start": 37200000,
+    "end": 40600000,
+    "name": "22.q13.1",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 807,
+    "chromosome": "chr22",
+    "start": 40600000,
+    "end": 43800000,
+    "name": "22.q13.2",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 808,
+    "chromosome": "chr22",
+    "start": 43800000,
+    "end": 48100000,
+    "name": "22.q13.31",
+    "giemsaStains": "gneg"
+  },
+  {
+    "id": 809,
+    "chromosome": "chr22",
+    "start": 48100000,
+    "end": 49100000,
+    "name": "22.q13.32",
+    "giemsaStains": "gpos50"
+  },
+  {
+    "id": 810,
+    "chromosome": "chr22",
+    "start": 49100000,
+    "end": 50818468,
+    "name": "22.q13.33",
+    "giemsaStains": "gneg"
+  }
+]

--- a/src/scripts/cytoBand.txt
+++ b/src/scripts/cytoBand.txt
@@ -1,4 +1,3 @@
-#chrom	chromStart	chromEnd	name	gieStain
 chr1	0	2300000	p36.33	gneg
 chr1	2300000	5300000	p36.32	gpos25
 chr1	5300000	7100000	p36.31	gneg

--- a/src/scripts/genomeTransformer.ts
+++ b/src/scripts/genomeTransformer.ts
@@ -5,7 +5,10 @@ import { exit } from 'process';
 
 type EntryTuple = [string, string, string, string, string];
 
+let count = 0;
+
 export interface CytoBandData {
+  id: number;
   chromosome: string;
   start: number;
   end: number;
@@ -21,6 +24,7 @@ function serialize([
   giemsaStains,
 ]: EntryTuple): CytoBandData {
   return {
+    id: count++,
     chromosome,
     start: parseInt(start),
     end: parseInt(end),

--- a/src/scripts/genomeTransformer.ts
+++ b/src/scripts/genomeTransformer.ts
@@ -24,7 +24,7 @@ function serialize([
     chromosome,
     start: parseInt(start),
     end: parseInt(end),
-    name: name === '' ? undefined : name,
+    name: name === '' ? undefined : chromosome.substring(3) + '.' + name,
     giemsaStains,
   };
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -13,15 +9,12 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
-    "module": "esnext",
+    "module": "commonjs",
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "include": [
-    "src",
-    ".eslintrc.js"
-  ]
+  "include": ["src", ".eslintrc.js"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -9,12 +13,15 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
-    "module": "commonjs",
+    "module": "esnext",
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "include": ["src", ".eslintrc.js"]
+  "include": [
+    "src",
+    ".eslintrc.js"
+  ]
 }


### PR DESCRIPTION
The only change was to include chromosome name in the cytoband names. So instead of a cytoband being named p36.33 it will be 1.p36.33. This is important because the addition of the chromosome guarantees that the cytoband names are unique. The only question is whether we should change the field name from "name" to "id".