### PR TITLE
feat: add localStorage caching for BLAST search results

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "tailwind-merge": "^2.2.0"
       },
       "devDependencies": {
-        "@types/node": "25.2.3",
         "@types/react": "^18.2.55",
         "@types/react-dom": "^18.2.19",
         "@vitejs/plugin-react": "^4.2.1",
@@ -1226,6 +1225,8 @@
       "integrity": "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2656,7 +2657,9 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",

--- a/src/components/blast/BlastHistory.tsx
+++ b/src/components/blast/BlastHistory.tsx
@@ -1,0 +1,63 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Clock, Trash2 } from 'lucide-react';
+import type { CachedBlastSearch } from '@/services/blast-cache-service';
+
+interface BlastHistoryProps {
+  searches: CachedBlastSearch[];
+  onSelect: (search: CachedBlastSearch) => void;
+  onDelete: (id: string) => void;
+}
+
+function formatTime(ts: number): string {
+  const d = new Date(ts);
+  return d.toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+export function BlastHistory({ searches, onSelect, onDelete }: BlastHistoryProps) {
+  if (searches.length === 0) return null;
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-2 text-base">
+          <Clock className="h-4 w-4" />
+          Previous Searches
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-1">
+        {searches.map((s) => (
+          <div
+            key={s.id}
+            className="flex items-center justify-between rounded-md px-3 py-2 hover:bg-muted/50 cursor-pointer group"
+            onClick={() => onSelect(s)}
+          >
+            <div className="min-w-0 flex-1">
+              <p className="truncate font-mono text-sm">{s.label}</p>
+              <p className="text-xs text-muted-foreground">
+                {formatTime(s.timestamp)} · {s.matches.length} gene{s.matches.length !== 1 ? 's' : ''}
+                {s.metadata?.best_gene_symbol && ` · Best: ${s.metadata.best_gene_symbol}`}
+              </p>
+            </div>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="ml-2 opacity-0 group-hover:opacity-100 h-7 w-7 p-0"
+              onClick={(e) => {
+                e.stopPropagation();
+                onDelete(s.id);
+              }}
+            >
+              <Trash2 className="h-3.5 w-3.5 text-muted-foreground" />
+            </Button>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/pages/AnalyzerPage.tsx
+++ b/src/pages/AnalyzerPage.tsx
@@ -1,11 +1,14 @@
 import { BlastInput } from '@/components/blast/BlastInput';
 import { BlastResults } from '@/components/blast/BlastResults';
+import { BlastHistory } from '@/components/blast/BlastHistory';
 import { useBlastSearch } from '@/hooks/useBlastSearch';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 
 export function AnalyzerPage() {
-  const { sequence, setSequence, matches, metadata, isLoading, error, runSearch, clear } =
-    useBlastSearch();
+  const {
+    sequence, setSequence, matches, metadata, isLoading, error,
+    runSearch, clear, cachedSearches, loadCached, removeFromCache,
+  } = useBlastSearch();
 
   return (
     <div className="mx-auto max-w-4xl space-y-6 p-6">
@@ -41,6 +44,12 @@ export function AnalyzerPage() {
       )}
 
       <BlastResults matches={matches} metadata={metadata} />
+
+      <BlastHistory
+        searches={cachedSearches}
+        onSelect={loadCached}
+        onDelete={removeFromCache}
+      />
     </div>
   );
 }

--- a/src/services/blast-cache-service.ts
+++ b/src/services/blast-cache-service.ts
@@ -1,0 +1,60 @@
+import type { BlastMatch, BlastMetaData } from '@/types/blast';
+
+const STORAGE_KEY = 'visionome:blast-cache';
+const MAX_ENTRIES = 20;
+
+export interface CachedBlastSearch {
+  id: string;
+  label: string;
+  timestamp: number;
+  matches: BlastMatch[];
+  metadata: BlastMetaData | null;
+}
+
+function generateId(): string {
+  return Date.now().toString(36) + Math.random().toString(36).slice(2, 7);
+}
+
+/** Build a short human-readable label from a raw sequence. */
+function buildLabel(sequence: string): string {
+  const clean = sequence.replace(/\s+/g, '');
+  const preview = clean.slice(0, 20);
+  return clean.length > 20 ? `${preview}…` : preview;
+}
+
+export function getCachedSearches(): CachedBlastSearch[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as CachedBlastSearch[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function saveSearch(
+  sequence: string,
+  matches: BlastMatch[],
+  metadata: BlastMetaData | null,
+): CachedBlastSearch {
+  const entry: CachedBlastSearch = {
+    id: generateId(),
+    label: buildLabel(sequence),
+    timestamp: Date.now(),
+    matches,
+    metadata,
+  };
+
+  const existing = getCachedSearches();
+  const updated = [entry, ...existing].slice(0, MAX_ENTRIES);
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+  return entry;
+}
+
+export function getCachedSearch(id: string): CachedBlastSearch | undefined {
+  return getCachedSearches().find((s) => s.id === id);
+}
+
+export function deleteCachedSearch(id: string): void {
+  const updated = getCachedSearches().filter((s) => s.id !== id);
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+}


### PR DESCRIPTION
## Summary
Adds localStorage-based caching for BLAST sequence analyzer results, so previously run searches can be instantly loaded without re-running the BLAST query.

<img width="891" height="628" alt="image" src="https://github.com/user-attachments/assets/7fbf0e19-4c27-4543-9cd6-0974f976dd78" />

<img width="933" height="976" alt="image" src="https://github.com/user-attachments/assets/4361a8bf-06bb-452b-b74f-7e643b449d2e" />


## Changes
- **`src/services/blast-cache-service.ts`** — new service for saving/loading/deleting cached BLAST searches in localStorage (up to 20 entries)
- **`src/components/blast/BlastHistory.tsx`** — new "Previous Searches" component listing cached searches with timestamp, gene count, and best match info
- **`src/hooks/useBlastSearch.ts`** — integrates caching: auto-saves after each search, exposes `cachedSearches`, `loadCached`, and `removeFromCache`
- **`src/pages/AnalyzerPage.tsx`** — renders the BlastHistory component

## Details
- Clicking a cached search loads the results table instantaneously
- Each entry stores matches, metadata, timestamp, and a sequence preview (first 20 chars) — the full FASTA/sequence is **not** stored
- Hover over an entry to reveal a delete button
- Oldest entries are evicted when the 20-entry limit is reached